### PR TITLE
Fix BoxUV models have bottom face flipped vertically (1.15) and fix normals

### DIFF
--- a/src/main/java/software/bernie/geckolib3/geo/render/built/GeoCube.java
+++ b/src/main/java/software/bernie/geckolib3/geo/render/built/GeoCube.java
@@ -133,7 +133,7 @@ public class GeoCube
 			quadNorth = new GeoQuad(new GeoVertex[]{P3, P7, P5, P1}, new double[] {UV[0] + UVSize.z, UV[1] + UVSize.z}, new double[] {UVSize.x, UVSize.y}, textureWidth, textureHeight, cubeIn.getMirror(), Direction.NORTH);
 			quadSouth = new GeoQuad(new GeoVertex[]{P8, P4, P2, P6},  new double[] {UV[0] + UVSize.z + UVSize.x + UVSize.z, UV[1] + UVSize.z}, new double[] {UVSize.x, UVSize.y}, textureWidth, textureHeight, cubeIn.getMirror(), Direction.SOUTH);
 			quadUp = new GeoQuad(new GeoVertex[]{P4, P8, P7, P3}, new double[] {UV[0] + UVSize.z, UV[1]}, new double[] {UVSize.x, UVSize.z}, textureWidth, textureHeight, cubeIn.getMirror(), Direction.UP);
-			quadDown = new GeoQuad(new GeoVertex[]{P1, P5, P6, P2}, new double[] {UV[0] + UVSize.z + UVSize.x, UV[1]}, new double[] {UVSize.x, UVSize.z}, textureWidth, textureHeight, cubeIn.getMirror(), Direction.DOWN);
+			quadDown = new GeoQuad(new GeoVertex[]{P2, P6, P5, P1}, new double[] {UV[0] + UVSize.z + UVSize.x, UV[1]}, new double[] {UVSize.x, UVSize.z}, textureWidth, textureHeight, cubeIn.getMirror(), Direction.DOWN);
 
 			if(cubeIn.getMirror() == Boolean.TRUE || mirror == Boolean.TRUE)
 			{

--- a/src/main/java/software/bernie/geckolib3/geo/render/built/GeoCube.java
+++ b/src/main/java/software/bernie/geckolib3/geo/render/built/GeoCube.java
@@ -11,16 +11,21 @@ public class GeoCube
 	public GeoQuad[] quads = new GeoQuad[6];
 	public Vector3f pivot;
 	public Vector3f rotation;
+	public Vector3f size = new Vector3f();
 	public double inflate;
 	public Boolean mirror;
 
-	private GeoCube()
+	private GeoCube(double[] size)
 	{
+		if (size.length >= 3)
+		{
+			this.size.set((float) size[0], (float) size[1], (float) size[2]);
+		}
 	}
 
 	public static GeoCube createFromPojoCube(Cube cubeIn, ModelProperties properties, Double boneInflate, Boolean mirror)
 	{
-		GeoCube cube = new GeoCube();
+		GeoCube cube = new GeoCube(cubeIn.getSize());
 
 		UvUnion uvUnion = cubeIn.getUv();
 		UvFaces faces = uvUnion.faceUV;

--- a/src/main/java/software/bernie/geckolib3/renderers/geo/IGeoRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/IGeoRenderer.java
@@ -73,15 +73,16 @@ public interface IGeoRenderer<T>
 			Vector3f normal = quad.normal.copy();
 			normal.transform(matrix3f);
 
-			if (normal.getX() < 0)
+			/* Fix shading dark shading for flat cubes + compatibility wish Optifine shaders */
+			if ((cube.size.getY() == 0 || cube.size.getZ() == 0) && normal.getX() < 0)
 			{
 				normal.mul(-1, 1, 1);
 			}
-			if (normal.getY() < 0)
+			if ((cube.size.getX() == 0 || cube.size.getZ() == 0) && normal.getY() < 0)
 			{
 				normal.mul(1, -1, 1);
 			}
-			if (normal.getZ() < 0)
+			if ((cube.size.getX() == 0 || cube.size.getY() == 0) && normal.getZ() < 0)
 			{
 				normal.mul(1, 1, -1);
 			}


### PR DESCRIPTION
This one fixes the same thing with box UV as `1.12.2` pull request (#56), however, it also fixes shading on the models incorrectly due to them being inverted in the positive direction. This is only needed when the cube is `0` size on any axis, I just added additional checks.