### PR TITLE
Fix armor anchors

### DIFF
--- a/src/main/java/software/bernie/geckolib3/renderers/geo/GeoArmorRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/GeoArmorRenderer.java
@@ -86,7 +86,7 @@ public abstract class GeoArmorRenderer<T extends ArmorItem & IAnimatable> extend
 
 	public void render(float partialTicks, MatrixStack stack, IVertexBuilder bufferIn, int packedLightIn)
 	{
-		stack.translate(0.0D, 1.501F, 0.0D);
+		stack.translate(0.0D, 24 / 16F, 0.0D);
 		stack.scale(-1.0F, -1.0F, 1.0F);
 		GeoModel model = modelProvider.getModel(modelProvider.getModelLocation(currentArmorItem));
 
@@ -94,50 +94,13 @@ public abstract class GeoArmorRenderer<T extends ArmorItem & IAnimatable> extend
 		modelProvider.setLivingAnimations(currentArmorItem, this.getUniqueID(this.currentArmorItem), itemEvent);
 		this.fitToBiped();
 		stack.push();
-		stack.translate(0, 0.01f, 0);
-		IBone rightArmBone = this.modelProvider.getBone(this.rightArmBone);
-		IBone leftArmBone = this.modelProvider.getBone(this.leftArmBone);
-		if (this.swingProgress > 0.0F)
-		{
-			rightArmBone.setScaleZ(1.25F);
-			rightArmBone.setScaleX(1.25F);
-			leftArmBone.setScaleZ(1.3F);
-			leftArmBone.setScaleX(1.05F);
-		}
-		if (isSneak)
-		{
-			IBone headBone = this.modelProvider.getBone(this.headBone);
-			IBone bodyBone = this.modelProvider.getBone(this.bodyBone);
-			IBone rightLegBone = this.modelProvider.getBone(this.rightLegBone);
-			IBone leftLegBone = this.modelProvider.getBone(this.leftLegBone);
-			IBone rightBootBone = this.modelProvider.getBone(this.rightBootBone);
-			IBone leftBootBone = this.modelProvider.getBone(this.leftBootBone);
-			try
-			{
-				headBone.setPositionY(headBone.getPositionY() - 5.35F);
-				bodyBone.setPositionZ(bodyBone.getPositionX() - 0.4F);
-				bodyBone.setPositionY(bodyBone.getPositionX() - 3.5F);
-				rightArmBone.setPositionY(bodyBone.getPositionX() - 3);
-				rightArmBone.setPositionX(bodyBone.getPositionX() + 0.35F);
-				leftArmBone.setPositionY(bodyBone.getPositionX() - 3);
-				leftArmBone.setPositionX(bodyBone.getPositionX() - 0.35F);
-				rightLegBone.setPositionZ(bodyBone.getPositionX() + 4);
-				leftLegBone.setPositionZ(bodyBone.getPositionX() + 4);
-				rightBootBone.setPositionZ(bodyBone.getPositionX() + 4);
-				leftBootBone.setPositionZ(bodyBone.getPositionX() + 4);
-			}
-			catch (Exception e)
-			{
-				throw new RuntimeException("Could not find an armor bone.", e);
-			}
-		}
 		Minecraft.getInstance().textureManager.bindTexture(getTextureLocation(currentArmorItem));
 		Color renderColor = getRenderColor(currentArmorItem, partialTicks, stack, null, bufferIn, packedLightIn);
 		RenderType renderType = getRenderType(currentArmorItem, partialTicks, stack, null, bufferIn, packedLightIn, getTextureLocation(currentArmorItem));
 		render(model, currentArmorItem, partialTicks, renderType, stack, null, bufferIn, packedLightIn, OverlayTexture.NO_OVERLAY, (float) renderColor.getRed() / 255f, (float) renderColor.getGreen() / 255f, (float) renderColor.getBlue() / 255f, (float) renderColor.getAlpha() / 255);
 		stack.pop();
 		stack.scale(-1.0F, -1.0F, 1.0F);
-		stack.translate(0.0D, -1.501F, 0.0D);
+		stack.translate(0.0D, -24 / 16F, 0.0D);
 	}
 
 	private void fitToBiped()
@@ -162,6 +125,33 @@ public abstract class GeoArmorRenderer<T extends ArmorItem & IAnimatable> extend
 				GeoUtils.copyRotations(this.bipedLeftLeg, leftLegBone);
 				GeoUtils.copyRotations(this.bipedRightLeg, rightBootBone);
 				GeoUtils.copyRotations(this.bipedLeftLeg, leftBootBone);
+
+				headBone.setPositionX(this.bipedHead.rotationPointX);
+				headBone.setPositionY(-this.bipedHead.rotationPointY);
+				headBone.setPositionZ(this.bipedHead.rotationPointZ);
+				bodyBone.setPositionX(this.bipedBody.rotationPointX);
+				bodyBone.setPositionY(-this.bipedBody.rotationPointY);
+				bodyBone.setPositionZ(this.bipedBody.rotationPointZ);
+
+				rightArmBone.setPositionX(this.bipedRightArm.rotationPointX + 5);
+				rightArmBone.setPositionY(2 - this.bipedRightArm.rotationPointY);
+				rightArmBone.setPositionZ(this.bipedRightArm.rotationPointZ);
+				leftArmBone.setPositionX(this.bipedLeftArm.rotationPointX - 5);
+				leftArmBone.setPositionY(2 - this.bipedLeftArm.rotationPointY);
+				leftArmBone.setPositionZ(this.bipedLeftArm.rotationPointZ);
+
+				rightLegBone.setPositionX(this.bipedRightLeg.rotationPointX + 2);
+				rightLegBone.setPositionY(12 - this.bipedRightLeg.rotationPointY);
+				rightLegBone.setPositionZ(this.bipedRightLeg.rotationPointZ);
+				leftLegBone.setPositionX(this.bipedLeftLeg.rotationPointX - 2);
+				leftLegBone.setPositionY(12 - this.bipedLeftLeg.rotationPointY);
+				leftLegBone.setPositionZ(this.bipedLeftLeg.rotationPointZ);
+				rightBootBone.setPositionX(this.bipedRightLeg.rotationPointX + 2);
+				rightBootBone.setPositionY(12 - this.bipedRightLeg.rotationPointY);
+				rightBootBone.setPositionZ(this.bipedRightLeg.rotationPointZ);
+				leftBootBone.setPositionX(this.bipedLeftLeg.rotationPointX - 2);
+				leftBootBone.setPositionY(12 - this.bipedLeftLeg.rotationPointY);
+				leftBootBone.setPositionZ(this.bipedLeftLeg.rotationPointZ);
 			}
 		}
 		catch (Exception e)

--- a/src/main/resources/assets/geckolib3/geo/potato_armor.geo.json
+++ b/src/main/resources/assets/geckolib3/geo/potato_armor.geo.json
@@ -18,7 +18,7 @@
 				{
 					"name": "helmet",
 					"parent": "armor",
-					"pivot": [0, 24.75, 0],
+					"pivot": [0, 24, 0],
 					"cubes": [
 						{"origin": [-4, 26, -4], "size": [8, 6, 9], "inflate": 0.6, "uv": [0, 0]}
 					]
@@ -107,7 +107,7 @@
 				{
 					"name": "chestplate",
 					"parent": "armor",
-					"pivot": [0, 25, 0],
+					"pivot": [0, 24, 0],
 					"cubes": [
 						{"origin": [-4, 12, -2], "size": [8, 12, 4], "inflate": 0.6, "uv": [0, 15]}
 					]
@@ -124,7 +124,7 @@
 				{
 					"name": "rightArm",
 					"parent": "armor",
-					"pivot": [-6.5, 21.5, 0],
+					"pivot": [-6, 22, 0],
 					"cubes": [
 						{"origin": [-8, 19, -2], "size": [3, 5, 4], "inflate": 0.6, "uv": [48, 30]},
 						{"origin": [-9.5, 17.5, -3], "size": [4, 2, 6], "uv": [24, 15]}
@@ -158,7 +158,7 @@
 				{
 					"name": "leftArm",
 					"parent": "armor",
-					"pivot": [6.5, 21.5, 0],
+					"pivot": [6, 22, 0],
 					"cubes": [
 						{"origin": [5, 19, -2], "size": [3, 5, 4], "inflate": 0.6, "uv": [12, 47]},
 						{"origin": [5.5, 17.5, -3], "size": [4, 2, 6], "uv": [24, 24]}


### PR DESCRIPTION
Armor anchor points rework, @grillo78 asked me to take a look at it, and honestly the armor implementation was a mess. The scaling on swing, and other stuff are pretty much ugly hacks. Here is a better version, however here are a couple of condition that must be followed in order for the model to appear correctly:

* The armor anchor points should be:
    * `0, 24, 0` for `helmet`
    * `0, 24, 0` for `chestplate`
    * `6, 22, 0` for `rightArm`
    * `-6, 24, 0` for `leftArm`
    * `2, 12, 0` for `rightBoot` and `rightLeg`
    * `-2, 12, 0` for `leftBoot` and `leftLeg`

These changes were applied to potato armor which appears now correctly on top of Steve character. I haven't tested on Alex, but it should apply correctly there as well (and even take in account the arms being lower and closer to the body, I think).