### PR TITLE
[1.16] Fix armor model anchor (again)

### DIFF
--- a/src/main/resources/assets/geckolib3/geo/potato_armor.geo.json
+++ b/src/main/resources/assets/geckolib3/geo/potato_armor.geo.json
@@ -124,7 +124,7 @@
 				{
 					"name": "rightArm",
 					"parent": "armor",
-					"pivot": [-6, 22, 0],
+					"pivot": [-5, 22, 0],
 					"cubes": [
 						{"origin": [-8, 19, -2], "size": [3, 5, 4], "inflate": 0.6, "uv": [48, 30]},
 						{"origin": [-9.5, 17.5, -3], "size": [4, 2, 6], "uv": [24, 15]}
@@ -158,7 +158,7 @@
 				{
 					"name": "leftArm",
 					"parent": "armor",
-					"pivot": [6, 22, 0],
+					"pivot": [5, 22, 0],
 					"cubes": [
 						{"origin": [5, 19, -2], "size": [3, 5, 4], "inflate": 0.6, "uv": [12, 47]},
 						{"origin": [5.5, 17.5, -3], "size": [4, 2, 6], "uv": [24, 24]}


### PR DESCRIPTION
Apparently, I was wrong about armor anchor points. I suppose Mojang changed the anchor point from `6` to `5` somewhere after `1.13`. So there are new anchor points needed for armors:

* The armor anchor points should be:
    * `0, 24, 0` for `helmet`
    * `0, 24, 0` for `chestplate`
    * `5, 22, 0` for `rightArm` (instead of `-5`)
    * `-5, 24, 0` for `leftArm` (instead of `-6`)
    * `2, 12, 0` for `rightBoot` and `rightLeg`
    * `-2, 12, 0` for `leftBoot` and `leftLeg`

This is the same thing as #77 but for `1.16`.