### PR TITLE
Updated GeoLayer to no longer use java models

### DIFF
--- a/src/main/java/software/bernie/geckolib3/renderers/geo/GeoLayerRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/GeoLayerRenderer.java
@@ -1,19 +1,18 @@
 package software.bernie.geckolib3.renderers.geo;
 
-import javax.annotation.Nullable;
-
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.vertex.IVertexBuilder;
 
 import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.entity.LivingRenderer;
-import net.minecraft.client.renderer.entity.model.EntityModel;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.ResourceLocation;
 import software.bernie.geckolib3.core.IAnimatable;
+import software.bernie.geckolib3.geo.render.built.GeoModel;
 import software.bernie.geckolib3.model.provider.GeoModelProvider;
+import software.bernie.geckolib3.util.AnimationUtils;
 
 public abstract class GeoLayerRenderer<T extends Entity & IAnimatable>
 {
@@ -24,22 +23,21 @@ public abstract class GeoLayerRenderer<T extends Entity & IAnimatable>
 		this.entityRenderer = entityRendererIn;
 	}
 
-	protected static <T extends LivingEntity> void renderCopyModel(EntityModel<T> modelParentIn, EntityModel<T> modelIn, ResourceLocation textureLocationIn, MatrixStack matrixStackIn, IRenderTypeBuffer bufferIn, int packedLightIn, T entityIn, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch, float partialTicks, float red, float green, float blue)
+	protected static <T extends LivingEntity & IAnimatable> void renderCopyModel(GeoModelProvider<T> modelProviderIn, ResourceLocation textureLocationIn, MatrixStack matrixStackIn, IRenderTypeBuffer bufferIn, int packedLightIn, T entityIn, float partialTicks, float red, float green, float blue)
 	{
 		if (!entityIn.isInvisible())
 		{
-			modelParentIn.copyModelAttributesTo(modelIn);
-			modelIn.setLivingAnimations(entityIn, limbSwing, limbSwingAmount, partialTicks);
-			modelIn.setRotationAngles(entityIn, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch);
-			renderModel(modelIn, textureLocationIn, matrixStackIn, bufferIn, packedLightIn, entityIn, red, green, blue);
+			renderModel(modelProviderIn, textureLocationIn, matrixStackIn, bufferIn, packedLightIn, entityIn, partialTicks, red, green, blue);
 		}
 	}
 
-	protected static <T extends LivingEntity> void renderModel(EntityModel<T> modelIn, ResourceLocation textureLocationIn, MatrixStack matrixStackIn, IRenderTypeBuffer bufferIn, int packedLightIn, T entityIn, float red, float green, float blue)
+	protected static <T extends LivingEntity & IAnimatable> void renderModel(GeoModelProvider<T> modelProviderIn, ResourceLocation textureLocationIn, MatrixStack matrixStackIn, IRenderTypeBuffer bufferIn, int packedLightIn, T entityIn, float partialTicks, float red, float green, float blue)
 	{
+		GeoModel model = modelProviderIn.getModel(modelProviderIn.getModelLocation(entityIn));
+		IGeoRenderer<T> renderer = (IGeoRenderer<T>)AnimationUtils.getRenderer(entityIn);
 		RenderType renderType = getRenderType(textureLocationIn);
 		IVertexBuilder ivertexbuilder = bufferIn.getBuffer(renderType);
-		modelIn.render(matrixStackIn, ivertexbuilder, packedLightIn, LivingRenderer.getPackedOverlay(entityIn, 0.0F), red, green, blue, 1.0F);
+		renderer.render(model, entityIn, partialTicks, renderType, matrixStackIn, bufferIn, ivertexbuilder, packedLightIn, LivingRenderer.getPackedOverlay(entityIn, 0.0F), red, green, blue, 1.0F);
 	}
 
 	public static RenderType getRenderType(ResourceLocation textureLocation)


### PR DESCRIPTION
Trying to use the methods in GeoLayerRenderer I found that they were still using java models, this makes it impossible to use renderCopyModel or renderModel with geo models.

This PR changes the Entity Models to a Geo Provider making them possible to use.

![2021-01-25_03 40 01](https://user-images.githubusercontent.com/67644822/105682718-c9f5e800-5ec0-11eb-92ea-c2381cd25cb1.png)
_Screenshot from testing_