### PR TITLE
[1.15] Port AnimationTicker from 1.12, fixes stuttering issue

### DIFF
--- a/src/main/java/software/bernie/geckolib3/model/AnimationTicker.java
+++ b/src/main/java/software/bernie/geckolib3/model/AnimationTicker.java
@@ -1,0 +1,30 @@
+package software.bernie.geckolib3.model;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import software.bernie.geckolib3.core.manager.AnimationData;
+
+public class AnimationTicker
+{
+    private final AnimationData data;
+
+    public AnimationTicker(AnimationData data)
+    {
+        this.data = data;
+    }
+
+    @SubscribeEvent
+    public void tickEvent(TickEvent.ClientTickEvent event)
+    {
+        if(Minecraft.getInstance().isGamePaused() && !data.shouldPlayWhilePaused)
+        {
+            return;
+        }
+
+        if (event.phase == TickEvent.Phase.END)
+        {
+            data.tick++;
+        }
+    }
+}


### PR DESCRIPTION
By calculating seekTime properly, there is no more stuttering!
Also the model animations pause in the pause menu now too.