### PR TITLE
[1.16] Fix bottom face being flipped in BoxUV, re-enable culling.

### DIFF
--- a/src/main/java/software/bernie/geckolib3/geo/render/built/GeoCube.java
+++ b/src/main/java/software/bernie/geckolib3/geo/render/built/GeoCube.java
@@ -137,7 +137,7 @@ public class GeoCube
 			quadNorth = new GeoQuad(new GeoVertex[]{P3, P7, P5, P1}, new double[] {UV[0] + UVSize.z, UV[1] + UVSize.z}, new double[] {UVSize.x, UVSize.y}, textureWidth, textureHeight, cubeIn.getMirror(), Direction.NORTH);
 			quadSouth = new GeoQuad(new GeoVertex[]{P8, P4, P2, P6},  new double[] {UV[0] + UVSize.z + UVSize.x + UVSize.z, UV[1] + UVSize.z}, new double[] {UVSize.x, UVSize.y}, textureWidth, textureHeight, cubeIn.getMirror(), Direction.SOUTH);
 			quadUp = new GeoQuad(new GeoVertex[]{P4, P8, P7, P3}, new double[] {UV[0] + UVSize.z, UV[1]}, new double[] {UVSize.x, UVSize.z}, textureWidth, textureHeight, cubeIn.getMirror(), Direction.UP);
-			quadDown = new GeoQuad(new GeoVertex[]{P2, P6, P5, P1}, new double[] {UV[0] + UVSize.z + UVSize.x, UV[1]}, new double[] {UVSize.x, UVSize.z}, textureWidth, textureHeight, cubeIn.getMirror(), Direction.DOWN);
+			quadDown = new GeoQuad(new GeoVertex[]{P1, P5, P6, P2}, new double[] {UV[0] + UVSize.z + UVSize.x + UVSize.x, UV[1] + UVSize.z}, new double[] {-UVSize.x, -UVSize.z}, textureWidth, textureHeight, cubeIn.getMirror(), Direction.DOWN);
 
 			if(cubeIn.getMirror() == Boolean.TRUE || mirror == Boolean.TRUE)
 			{

--- a/src/main/java/software/bernie/geckolib3/renderers/geo/IGeoRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/IGeoRenderer.java
@@ -114,7 +114,7 @@ public interface IGeoRenderer<T>
 
 	default RenderType getRenderType(T animatable, float partialTicks, MatrixStack stack, @Nullable IRenderTypeBuffer renderTypeBuffer, @Nullable IVertexBuilder vertexBuilder, int packedLightIn, ResourceLocation textureLocation)
 	{
-		return RenderType.getEntityCutoutNoCull(textureLocation);
+		return RenderType.getEntityCutout(textureLocation);
 	}
 
 	default Color getRenderColor(T animatable, float partialTicks, MatrixStack stack, @Nullable IRenderTypeBuffer renderTypeBuffer, @Nullable IVertexBuilder vertexBuilder, int packedLightIn)


### PR DESCRIPTION
This fixes the normal of the bottom face facing upwards(which messes up backface culling) and flips the bottom texture vertically by flipping the uv region endpoints(top left and bottom right).