### PR TITLE
Fix GeckoArmor head bone position while sneaking

### DIFF
--- a/src/main/java/software/bernie/geckolib3/renderer/geo/GeoArmorRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderer/geo/GeoArmorRenderer.java
@@ -104,7 +104,6 @@ public abstract class GeoArmorRenderer<T extends ArmorItem & IAnimatable> extend
 			IBone rightBootBone = this.modelProvider.getBone(this.rightBootBone);
 			IBone leftBootBone = this.modelProvider.getBone(this.leftBootBone);
 			try {
-				headBone.setPositionY(headBone.getPositionY() - 5.35F);
 				bodyBone.setPositionZ(bodyBone.getPositionX() - 0.4F);
 				bodyBone.setPositionY(headBone.getPositionX() - 3.5F);
 				rightArmBone.setPositionY(bodyBone.getPositionX() - 3);


### PR DESCRIPTION
The gecko armor helmets were being positioned wrong while sneaking on the fabric version