### PR TITLE
Fix renderColor's blue/green being flipped

### DIFF
--- a/src/main/java/software/bernie/geckolib3/renderers/geo/GeoEntityRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/GeoEntityRenderer.java
@@ -143,8 +143,8 @@ public abstract class GeoEntityRenderer<T extends LivingEntity & IAnimatable> ex
 				getEntityTexture(entity));
 		boolean invis = entity.isInvisibleToPlayer(Minecraft.getInstance().player);
 		render(model, entity, partialTicks, renderType, stack, bufferIn, null, packedLightIn,
-				getPackedOverlay(entity, 0), (float) renderColor.getRed() / 255f, (float) renderColor.getBlue() / 255f,
-				(float) renderColor.getGreen() / 255f, invis ? 0.0F : (float) renderColor.getAlpha() / 255);
+				getPackedOverlay(entity, 0), (float) renderColor.getRed() / 255f, (float) renderColor.getGreen() / 255f,
+				(float) renderColor.getBlue() / 255f, invis ? 0.0F : (float) renderColor.getAlpha() / 255);
 
 		if (!entity.isSpectator()) {
 			for (GeoLayerRenderer<T> layerRenderer : this.layerRenderers) {

--- a/src/main/java/software/bernie/geckolib3/renderers/geo/GeoReplacedEntityRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/GeoReplacedEntityRenderer.java
@@ -158,8 +158,8 @@ public abstract class GeoReplacedEntityRenderer<T extends IAnimatable> extends E
 		boolean invis = entity.isInvisibleToPlayer(Minecraft.getInstance().player);
 		render(model, entity, partialTicks, renderType, stack, bufferIn, null, packedLightIn,
 				getPackedOverlay(entityLiving, this.getOverlayProgress(entityLiving, partialTicks)),
-				(float) renderColor.getRed() / 255f, (float) renderColor.getBlue() / 255f,
-				(float) renderColor.getGreen() / 255f, invis ? 0.0F : (float) renderColor.getAlpha() / 255);
+				(float) renderColor.getRed() / 255f, (float) renderColor.getGreen() / 255f,
+				(float) renderColor.getBlue() / 255f, invis ? 0.0F : (float) renderColor.getAlpha() / 255);
 
 		if (!entity.isSpectator()) {
 			for (GeoLayerRenderer layerRenderer : this.layerRenderers) {


### PR DESCRIPTION
Only appears to be an issue with GeoEntityRenderer and GeoReplacedEntityRenderer, other renderers are fine.