### PR TITLE
Remove duplicate call to render() in ItemRenderer

### DIFF
--- a/src/main/java/software/bernie/geckolib3/renderers/geo/GeoItemRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/GeoItemRenderer.java
@@ -72,7 +72,6 @@ public abstract class GeoItemRenderer<T extends Item & IAnimatable> extends Item
 		} else {
 			this.render((T) itemStack.getItem(), matrixStack, bufferIn, combinedLightIn, itemStack);
 		}
-		this.render((T) itemStack.getItem(), matrixStack, bufferIn, combinedLightIn, itemStack);
 	}
 
 	public void render(T animatable, MatrixStack stack, IRenderTypeBuffer bufferIn, int packedLightIn,


### PR DESCRIPTION
Seems to significantly improve fps when rendering items with no loss of functionality (looks like a typo)