### PR TITLE
Add basic ISyncable system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 buildscript {
     repositories {
-        maven { url = 'https://files.minecraftforge.net/maven' }
+        maven { url = 'https://maven.minecraftforge.net/' }
 		maven { url  = 'https://plugins.gradle.org/m2/' }
         jcenter()
         mavenCentral()
@@ -39,10 +39,12 @@ minecraft {
     mappings channel:"official", version:"1.16.5"
     runs {
         client {
-            workingDirectory project.file('run')
+            workingDirectory project.file('runs/' + name)
+            singleInstance true
+            taskName 'Client'
+
             property 'forge.logging.console.level', 'debug'
-            //For Mixin in other mods / Patchouli
-            properties 'mixin.env.remapRefMap': 'true'
+            property 'mixin.env.remapRefMap', 'true'
             property 'mixin.env.refMapRemappingFile', "${project.projectDir}/build/createSrgToMcp/output.srg"
             mods {
                 geckolib {
@@ -51,12 +53,25 @@ minecraft {
             }
         }
 
+        clientAlt {
+            parent minecraft.runs.client
+            workingDirectory project.file('runs/' + name)
+            taskName 'ClientAlt'
+            args '--username', 'Alt'
+        }
+
         server {
-            workingDirectory project.file('run')
+            workingDirectory project.file('runs/' + name)
+            singleInstance true
+            taskName 'Server'
+
             property 'forge.logging.console.level', 'debug'
-            //For Mixin in other mods / Patchouli
-            properties 'mixin.env.remapRefMap': 'true'
+            property 'mixin.env.remapRefMap', 'true'
             property 'mixin.env.refMapRemappingFile', "${project.projectDir}/build/createSrgToMcp/output.srg"
+
+            // Uncomment this to run the server without the GUI
+            //args 'nogui'
+
             mods {
                 geckolib {
                     source sourceSets.main
@@ -65,12 +80,16 @@ minecraft {
         }
 
         data {
-            workingDirectory project.file('run')
-            property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-            //For Mixin in other mods / Patchouli
-            properties 'mixin.env.remapRefMap': 'true'
+            workingDirectory project.file('runs/' + name)
+            singleInstance true
+            taskName 'Data'
+
+            property 'forge.logging.console.level', 'debug'
+            property 'mixin.env.remapRefMap', 'true'
             property 'mixin.env.refMapRemappingFile', "${project.projectDir}/build/createSrgToMcp/output.srg"
-            args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/')
+
+            args '--mod', 'geckolib3', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
+
             mods {
                 geckolib {
                     source sourceSets.main

--- a/src/main/java/software/bernie/example/GeckoLibMod.java
+++ b/src/main/java/software/bernie/example/GeckoLibMod.java
@@ -13,6 +13,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import software.bernie.example.registry.*;
 import software.bernie.geckolib3.GeckoLib;
+import software.bernie.geckolib3.network.GeckoLibNetwork;
 
 @Mod(GeckoLib.ModID)
 public class GeckoLibMod {
@@ -21,6 +22,7 @@ public class GeckoLibMod {
 
 	public GeckoLibMod() {
 		GeckoLib.initialize();
+		GeckoLibNetwork.initialize();
 		if (!FMLEnvironment.production && !DISABLE_IN_DEV) {
 			IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
 			EntityRegistry.ENTITIES.register(bus);

--- a/src/main/java/software/bernie/geckolib3/network/GeckoLibNetwork.java
+++ b/src/main/java/software/bernie/geckolib3/network/GeckoLibNetwork.java
@@ -1,0 +1,60 @@
+package software.bernie.geckolib3.network;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.network.NetworkRegistry;
+import net.minecraftforge.fml.network.PacketDistributor;
+import net.minecraftforge.fml.network.simple.SimpleChannel;
+import net.minecraftforge.registries.ForgeRegistryEntry;
+import net.minecraftforge.registries.IRegistryDelegate;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import software.bernie.geckolib3.GeckoLib;
+import software.bernie.geckolib3.network.messages.SyncAnimationMsg;
+
+public class GeckoLibNetwork {
+    private static final Map<String, Supplier<ISyncable>> SYNCABLES = new HashMap<>();
+
+    private static final String PROTOCOL_VERSION = "0"; // This should be updated whenever packets change
+    private static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(
+            new ResourceLocation(GeckoLib.ModID, "main"),
+            () -> PROTOCOL_VERSION,
+            PROTOCOL_VERSION::equals,
+            PROTOCOL_VERSION::equals);
+
+    public static void initialize() {
+        // This would get incremented for every new message,
+        // but we only have one right now
+        int id = -1;
+
+        // Server --> Client
+        SyncAnimationMsg.register(CHANNEL, ++id);
+    }
+
+    public static void syncAnimation(PacketDistributor.PacketTarget target, ISyncable syncable, int id, int state) {
+        if (!target.getDirection().getOriginationSide().isServer()) {
+            throw new IllegalArgumentException("Only the server can request animation syncs!");
+        }
+        final String key = syncable.getSyncKey();
+        if (!SYNCABLES.containsKey(key)) {
+            throw new IllegalArgumentException("Syncable not registered for " + key);
+        }
+        CHANNEL.send(target, new SyncAnimationMsg(key, id, state));
+    }
+
+    public static ISyncable getSyncable(String key) {
+        final Supplier<ISyncable> delegate = SYNCABLES.get(key);
+        return delegate == null ? null : delegate.get();
+    }
+
+    public static <E extends ForgeRegistryEntry<E>, T extends ForgeRegistryEntry<E> & ISyncable> void registerSyncable(T entry) {
+        final IRegistryDelegate<?> delegate = entry.delegate;
+        final String key = entry.getSyncKey();
+        if (SYNCABLES.putIfAbsent(key, () -> (ISyncable) delegate.get()) != null) {
+            throw new IllegalArgumentException("Syncable already registered for " + key);
+        }
+        GeckoLib.LOGGER.debug("Registered syncable for " + key);
+    }
+}

--- a/src/main/java/software/bernie/geckolib3/network/ISyncable.java
+++ b/src/main/java/software/bernie/geckolib3/network/ISyncable.java
@@ -1,0 +1,9 @@
+package software.bernie.geckolib3.network;
+
+public interface ISyncable {
+    void onAnimationSync(int id, int state);
+
+    default String getSyncKey() {
+        return this.getClass().getName();
+    }
+}

--- a/src/main/java/software/bernie/geckolib3/network/messages/SyncAnimationMsg.java
+++ b/src/main/java/software/bernie/geckolib3/network/messages/SyncAnimationMsg.java
@@ -1,0 +1,61 @@
+package software.bernie.geckolib3.network.messages;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.fml.network.NetworkDirection;
+import net.minecraftforge.fml.network.NetworkEvent;
+import net.minecraftforge.fml.network.simple.SimpleChannel;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import software.bernie.geckolib3.GeckoLib;
+import software.bernie.geckolib3.network.GeckoLibNetwork;
+import software.bernie.geckolib3.network.ISyncable;
+
+public class SyncAnimationMsg {
+    private final String key;
+    private final int id;
+    private final int state;
+
+    public SyncAnimationMsg(String key, int id, int state) {
+        this.key = key;
+        this.id = id;
+        this.state = state;
+    }
+
+    public static void register(SimpleChannel channel, int id) {
+        channel.registerMessage(
+                id,
+                SyncAnimationMsg.class,
+                SyncAnimationMsg::encode,
+                SyncAnimationMsg::decode,
+                SyncAnimationMsg::handle,
+                Optional.of(NetworkDirection.PLAY_TO_CLIENT));
+    }
+
+    private static SyncAnimationMsg decode(PacketBuffer buf) {
+        final String key = buf.readUtf(32767); // The max length here can be removed in 1.17+
+        final int id = buf.readVarInt();
+        final int state = buf.readVarInt();
+        return new SyncAnimationMsg(key, id, state);
+    }
+
+    private void encode(PacketBuffer buf) {
+        buf.writeUtf(key);
+        buf.writeVarInt(id);
+        buf.writeVarInt(state);
+    }
+
+    private void handle(Supplier<NetworkEvent.Context> sup) {
+        final NetworkEvent.Context ctx = sup.get();
+        ctx.enqueueWork(() -> {
+            final ISyncable syncable = GeckoLibNetwork.getSyncable(key);
+            if (syncable != null) {
+                syncable.onAnimationSync(id, state);
+            } else {
+                GeckoLib.LOGGER.warn("Syncable on the server is missing on the client for " + key);
+            }
+        });
+        ctx.setPacketHandled(true);
+    }
+}

--- a/src/main/java/software/bernie/geckolib3/renderers/geo/GeoItemRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/GeoItemRenderer.java
@@ -21,6 +21,7 @@ import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.geo.render.built.GeoModel;
 import software.bernie.geckolib3.model.AnimatedGeoModel;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 public abstract class GeoItemRenderer<T extends Item & IAnimatable> extends ItemStackTileEntityRenderer
 		implements IGeoRenderer<T> {
@@ -110,6 +111,6 @@ public abstract class GeoItemRenderer<T extends Item & IAnimatable> extends Item
 
 	@Override
 	public Integer getUniqueID(T animatable) {
-		return currentItemStack.hashCode();
+		return GeckoLibUtil.getIDFromStack(currentItemStack);
 	}
 }

--- a/src/main/java/software/bernie/geckolib3/util/GeckoLibUtil.java
+++ b/src/main/java/software/bernie/geckolib3/util/GeckoLibUtil.java
@@ -1,16 +1,24 @@
 package software.bernie.geckolib3.util;
 
 import net.minecraft.item.ItemStack;
+
+import java.util.Objects;
+
 import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
 
 public class GeckoLibUtil {
 	public static int getIDFromStack(ItemStack stack) {
-		return stack.hashCode();
+		return Objects.hash(stack.getItem().getRegistryName(), stack.getTag(), stack.getCount());
 	}
 
 	public static AnimationController getControllerForStack(AnimationFactory factory, ItemStack stack,
 			String controllerName) {
-		return factory.getOrCreateAnimationData(getIDFromStack(stack)).getAnimationControllers().get(controllerName);
+		return getControllerForID(factory, getIDFromStack(stack), controllerName);
+	}
+
+	public static AnimationController getControllerForID(AnimationFactory factory, Integer id,
+			String controllerName) {
+		return factory.getOrCreateAnimationData(id).getAnimationControllers().get(controllerName);
 	}
 }


### PR DESCRIPTION
This allows modders to make their items, blocks, etc. automatically synced on the network.
To do so, objects should implement `ISyncable` and call `GeckoLibNetwork.registerSyncable(this);` in their constructor.
Then, simply call `GeckoLibNetwork#syncAnimation` on the server whenever the animation state changes. Clients that receive this packet will then automatically invoke `ISyncable#onAnimationSync`.
See `JackInTheBoxItem` for an example.

## Design Notes
You'll note that the `SYNCABLES` map uses `Supplier<ISyncable>` values. This is because Forge prefers people to store items, blocks, etc. using their delegates (see `registerSyncable`) since they can technically change at runtime? It's strange, but I designed the system around it.
For Fabric, this could probably be entirely tossed out and just use a direct reference to the items/blocks/etc.

## Known Issues
* The entire system only works on singletons, such as blocks and items, and won't work at all on entities. This is arguably ideal anyways since doing this automatically with non-singletons like entities would be kind of a design nightmare. Worth keeping in mind, though.

## PR Side Effects
* Changes the Forge maven URL to `https://maven.minecraftforge.net/`.
* Changes the run configs to aid in testing.
* Alters `GeckoLibUtil#getIDFromStack` to make it semi-unique; the previous `hashCode` on the item stack would always be random.
* Fixes `GeoItemRenderer` to use `GeckoLibUtil#getIDFromStack` for consistency.
* Adds `GeckoLibUtil#getControllerForID` and defers `GeckoLibUtil#getControllerForStack` through it.