### PR TITLE
Fix name refactoring issues causing AbstractMethodError 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,9 +5,10 @@ minecraft_version=1.16.5
 geckolib_core_version=1.0.4
 
 # Fabric
-yarn_mappings=1.16.5+build.3
-loader_version=0.11.1
-fabric_version=0.29.4+1.16
+yarn_mappings=1.16.5+build.10
+loader_version=0.11.6
+fabric_version=0.36.0+1.16
+
 
 # Mod Properties
 mod_version=3.0.40

--- a/src/main/java/software/bernie/example/registry/RegistryUtils.java
+++ b/src/main/java/software/bernie/example/registry/RegistryUtils.java
@@ -1,6 +1,6 @@
 package software.bernie.example.registry;
 
-import net.fabricmc.loader.FabricLoader;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
@@ -31,7 +31,7 @@ public class RegistryUtils {
 	}
 
 	public static <B extends Block> B register(B block, Identifier name, ItemGroup itemGroup) {
-		if (FabricLoader.INSTANCE.isDevelopmentEnvironment()) {
+		if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
 			Registry.register(Registry.BLOCK, name, block);
 			BlockItem item = new BlockItem(block, (new Settings()).group(itemGroup));
 			item.appendBlocks(Item.BLOCK_ITEMS, item);
@@ -41,28 +41,28 @@ public class RegistryUtils {
 	}
 
 	public static <B extends Block> B registerBlockWithoutItem(B block, Identifier identifier) {
-		if (FabricLoader.INSTANCE.isDevelopmentEnvironment()) {
+		if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
 			Registry.register(Registry.BLOCK, identifier, block);
 		}
 		return block;
 	}
 
 	public static <B extends Block> B registerBlockWithoutItem(String name, B block) {
-		if (FabricLoader.INSTANCE.isDevelopmentEnvironment()) {
+		if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
 			Registry.register(Registry.BLOCK, new Identifier(GeckoLib.ModID, name), block);
 		}
 		return block;
 	}
 
 	public static <I extends Item> I registerItem(I item, Identifier name) {
-		if (FabricLoader.INSTANCE.isDevelopmentEnvironment()) {
+		if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
 			return Registry.register(Registry.ITEM, name, item);
 		}
 		return null;
 	}
 
 	public static <I extends Item> I registerItem(String name, I item) {
-		if (FabricLoader.INSTANCE.isDevelopmentEnvironment()) {
+		if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
 			return Registry.register(Registry.ITEM, new Identifier(GeckoLib.ModID, name), item);
 		}
 		return null;
@@ -76,7 +76,7 @@ public class RegistryUtils {
 	}
 
 	public static <T extends BlockEntity> BlockEntityType<T> registerBlockEntity(String name, Builder<T> builder) {
-		if (FabricLoader.INSTANCE.isDevelopmentEnvironment()) {
+		if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
 			BlockEntityType<T> blockEntityType = builder.build(null);
 			Registry.register(Registry.BLOCK_ENTITY_TYPE, new Identifier(GeckoLib.ModID, name), blockEntityType);
 			return blockEntityType;
@@ -84,25 +84,25 @@ public class RegistryUtils {
 		return null;
 	}
 
-	public static Block registerNetherStem(Identifier name, MaterialColor materialColor) {
+	public static Block registerNetherStem(Identifier name, MapColor materialColor) {
 		return register(new PillarBlock(AbstractBlock.Settings.of(Material.WOOD, (blockState) -> materialColor)
 				.strength(1.0F).sounds(BlockSoundGroup.NETHER_STEM)), name);
 	}
 
-	public static Block registerLog(Identifier name, MaterialColor materialColor, MaterialColor materialColor2) {
+	public static Block registerLog(Identifier name, MapColor materialColor, MapColor materialColor2) {
 		return register(new PillarBlock(AbstractBlock.Settings.of(Material.WOOD,
 				(blockState) -> blockState.get(PillarBlock.AXIS) == Direction.Axis.Y ? materialColor : materialColor2)
 				.strength(2.0F).sounds(BlockSoundGroup.WOOD)), name);
 	}
 
-	public static Block registerNetherStem(String name, MaterialColor materialColor) {
+	public static Block registerNetherStem(String name, MapColor materialColor) {
 		return register(
 				new PillarBlock(AbstractBlock.Settings.of(Material.WOOD, (blockState) -> materialColor).strength(1.0F)
 						.sounds(BlockSoundGroup.NETHER_STEM)),
 				new Identifier(GeckoLib.ModID, name), ItemGroup.BUILDING_BLOCKS);
 	}
 
-	public static Block registerLog(String name, MaterialColor materialColor, MaterialColor materialColor2) {
+	public static Block registerLog(String name, MapColor materialColor, MapColor materialColor2) {
 		return register(
 				new PillarBlock(AbstractBlock.Settings.of(Material.WOOD,
 						(blockState) -> blockState.get(PillarBlock.AXIS) == Direction.Axis.Y ? materialColor

--- a/src/main/java/software/bernie/geckolib3/GeckoLib.java
+++ b/src/main/java/software/bernie/geckolib3/GeckoLib.java
@@ -8,6 +8,7 @@ package software.bernie.geckolib3;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+import net.minecraft.resource.ResourceReloader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -34,9 +35,9 @@ public class GeckoLib {
 						}
 
 						@Override
-						public CompletableFuture<Void> reload(Synchronizer synchronizer, ResourceManager manager,
-								Profiler prepareProfiler, Profiler applyProfiler, Executor prepareExecutor,
-								Executor applyExecutor) {
+						public CompletableFuture<Void> reload(ResourceReloader.Synchronizer synchronizer, ResourceManager manager,
+															  Profiler prepareProfiler, Profiler applyProfiler, Executor prepareExecutor,
+															  Executor applyExecutor) {
 							return GeckoLibCache.getInstance().reload(synchronizer, manager, prepareProfiler,
 									applyProfiler, prepareExecutor, applyExecutor);
 						}

--- a/src/main/java/software/bernie/geckolib3/geo/render/GeoBuilder.java
+++ b/src/main/java/software/bernie/geckolib3/geo/render/GeoBuilder.java
@@ -1,6 +1,6 @@
 package software.bernie.geckolib3.geo.render;
 
-import net.minecraft.client.util.math.Vector3f;
+import net.minecraft.util.math.Vec3f;
 import org.apache.commons.lang3.ArrayUtils;
 import software.bernie.geckolib3.geo.raw.pojo.Bone;
 import software.bernie.geckolib3.geo.raw.pojo.Cube;
@@ -26,8 +26,8 @@ public class GeoBuilder {
 		GeoBone geoBone = new GeoBone();
 
 		Bone rawBone = bone.selfBone;
-		Vector3f rotation = VectorUtils.convertDoubleToFloat(VectorUtils.fromArray(rawBone.getRotation()));
-		Vector3f pivot = VectorUtils.convertDoubleToFloat(VectorUtils.fromArray(rawBone.getPivot()));
+		Vec3f rotation = VectorUtils.convertDoubleToFloat(VectorUtils.fromArray(rawBone.getRotation()));
+		Vec3f pivot = VectorUtils.convertDoubleToFloat(VectorUtils.fromArray(rawBone.getPivot()));
 		rotation.multiplyComponentwise(-1, -1, 1);
 
 		geoBone.mirror = rawBone.getMirror();

--- a/src/main/java/software/bernie/geckolib3/geo/render/built/GeoCube.java
+++ b/src/main/java/software/bernie/geckolib3/geo/render/built/GeoCube.java
@@ -1,16 +1,16 @@
 package software.bernie.geckolib3.geo.render.built;
 
 import net.minecraft.client.util.math.Vector3d;
-import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3f;
 import software.bernie.geckolib3.geo.raw.pojo.*;
 import software.bernie.geckolib3.util.VectorUtils;
 
 public class GeoCube {
 	public GeoQuad[] quads = new GeoQuad[6];
-	public Vector3f pivot;
-	public Vector3f rotation;
-	public Vector3f size = new Vector3f();
+	public Vec3f pivot;
+	public Vec3f rotation;
+	public Vec3f size = new Vec3f();
 	public double inflate;
 	public Boolean mirror;
 
@@ -52,13 +52,13 @@ public class GeoCube {
 		if (size.z == 0) {
 			size.z = 0f;
 		}
-		Vector3f rotation = VectorUtils.convertDoubleToFloat(VectorUtils.fromArray(cubeIn.getRotation()));
+		Vec3f rotation = VectorUtils.convertDoubleToFloat(VectorUtils.fromArray(cubeIn.getRotation()));
 		rotation.multiplyComponentwise(-1, -1, 1);
 
 		rotation.set((float) Math.toRadians(rotation.getX()), (float) Math.toRadians(rotation.getY()),
 				(float) Math.toRadians(rotation.getZ()));
 
-		Vector3f pivot = VectorUtils.convertDoubleToFloat(VectorUtils.fromArray(cubeIn.getPivot()));
+		Vec3f pivot = VectorUtils.convertDoubleToFloat(VectorUtils.fromArray(cubeIn.getPivot()));
 		pivot.multiplyComponentwise(-1, 1, 1);
 
 		cube.pivot = pivot;

--- a/src/main/java/software/bernie/geckolib3/geo/render/built/GeoQuad.java
+++ b/src/main/java/software/bernie/geckolib3/geo/render/built/GeoQuad.java
@@ -1,10 +1,10 @@
 package software.bernie.geckolib3.geo.render.built;
 
-import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3f;
 
 public class GeoQuad {
-	public final Vector3f normal;
+	public final Vec3f normal;
 	public GeoVertex[] vertices;
 	public Direction direction;
 

--- a/src/main/java/software/bernie/geckolib3/geo/render/built/GeoVertex.java
+++ b/src/main/java/software/bernie/geckolib3/geo/render/built/GeoVertex.java
@@ -1,23 +1,23 @@
 package software.bernie.geckolib3.geo.render.built;
 
-import net.minecraft.client.util.math.Vector3f;
+import net.minecraft.util.math.Vec3f;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.Validate;
 
 public class GeoVertex {
-	public final Vector3f position;
+	public final Vec3f position;
 	public float textureU;
 	public float textureV;
 
 	public GeoVertex(float x, float y, float z) {
-		this.position = new Vector3f(x, y, z);
+		this.position = new Vec3f(x, y, z);
 	}
 
 	public GeoVertex(double x, double y, double z) {
-		this.position = new Vector3f((float) x, (float) y, (float) z);
+		this.position = new Vec3f((float) x, (float) y, (float) z);
 	}
 
-	public GeoVertex(Vector3f posIn, float texU, float texV) {
+	public GeoVertex(Vec3f posIn, float texU, float texV) {
 		this.position = posIn;
 		this.textureU = texU;
 		this.textureV = texV;

--- a/src/main/java/software/bernie/geckolib3/renderer/geo/GeoBlockRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderer/geo/GeoBlockRenderer.java
@@ -11,9 +11,9 @@ import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3f;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.geo.render.built.GeoModel;
@@ -77,22 +77,22 @@ public abstract class GeoBlockRenderer<T extends BlockEntity & IAnimatable> exte
 	protected void rotateBlock(Direction facing, MatrixStack stack) {
 		switch (facing) {
 		case SOUTH:
-			stack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(180));
+			stack.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(180));
 			break;
 		case WEST:
-			stack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(90));
+			stack.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(90));
 			break;
 		case NORTH:
-			stack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(0));
+			stack.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(0));
 			break;
 		case EAST:
-			stack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(270));
+			stack.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(270));
 			break;
 		case UP:
-			stack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(90));
+			stack.multiply(Vec3f.POSITIVE_X.getDegreesQuaternion(90));
 			break;
 		case DOWN:
-			stack.multiply(Vector3f.NEGATIVE_X.getDegreesQuaternion(90));
+			stack.multiply(Vec3f.NEGATIVE_X.getDegreesQuaternion(90));
 			break;
 		}
 	}

--- a/src/main/java/software/bernie/geckolib3/renderer/geo/GeoEntityRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderer/geo/GeoEntityRenderer.java
@@ -16,7 +16,6 @@ import net.minecraft.client.render.entity.EntityRenderDispatcher;
 import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.PlayerModelPart;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityPose;
 import net.minecraft.entity.EquipmentSlot;
@@ -27,6 +26,7 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3f;
 import software.bernie.geckolib3.compat.PatchouliCompat;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.IAnimatableModel;
@@ -174,7 +174,7 @@ public abstract class GeoEntityRenderer<T extends LivingEntity & IAnimatable> ex
 		stack.pop();
 		super.render(entity, entityYaw, partialTicks, stack, bufferIn, packedLightIn);
 	}
-	
+
 	@Override
 	public Integer getUniqueID(T animatable) {
 		return animatable.getEntityId();
@@ -210,7 +210,7 @@ public abstract class GeoEntityRenderer<T extends LivingEntity & IAnimatable> ex
 			float partialTicks) {
 		EntityPose pose = entityLiving.getPose();
 		if (pose != EntityPose.SLEEPING) {
-			matrixStackIn.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(180.0F - rotationYaw));
+			matrixStackIn.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(180.0F - rotationYaw));
 		}
 
 		if (entityLiving.deathTime > 0) {
@@ -221,23 +221,23 @@ public abstract class GeoEntityRenderer<T extends LivingEntity & IAnimatable> ex
 			}
 
 			matrixStackIn
-					.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(f * this.getDeathMaxRotation(entityLiving)));
+					.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(f * this.getDeathMaxRotation(entityLiving)));
 		} else if (entityLiving.isUsingRiptide()) {
-			matrixStackIn.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(-90.0F - entityLiving.pitch));
+			matrixStackIn.multiply(Vec3f.POSITIVE_X.getDegreesQuaternion(-90.0F - entityLiving.pitch));
 			matrixStackIn.multiply(
-					Vector3f.POSITIVE_Y.getDegreesQuaternion(((float) entityLiving.age + partialTicks) * -75.0F));
+					Vec3f.POSITIVE_Y.getDegreesQuaternion(((float) entityLiving.age + partialTicks) * -75.0F));
 		} else if (pose == EntityPose.SLEEPING) {
 			Direction direction = entityLiving.getSleepingDirection();
 			float f1 = direction != null ? getFacingAngle(direction) : rotationYaw;
-			matrixStackIn.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(f1));
-			matrixStackIn.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(this.getDeathMaxRotation(entityLiving)));
-			matrixStackIn.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(270.0F));
+			matrixStackIn.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(f1));
+			matrixStackIn.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(this.getDeathMaxRotation(entityLiving)));
+			matrixStackIn.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(270.0F));
 		} else if (entityLiving.hasCustomName() || entityLiving instanceof PlayerEntity) {
 			String s = Formatting.strip(entityLiving.getName().getString());
 			if (("Dinnerbone".equals(s) || "Grumm".equals(s)) && (!(entityLiving instanceof PlayerEntity)
 					|| ((PlayerEntity) entityLiving).isPartVisible(PlayerModelPart.CAPE))) {
 				matrixStackIn.translate(0.0D, entityLiving.getHeight() + 0.1F, 0.0D);
-				matrixStackIn.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(180.0F));
+				matrixStackIn.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(180.0F));
 			}
 		}
 

--- a/src/main/java/software/bernie/geckolib3/renderer/geo/GeoProjectilesRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderer/geo/GeoProjectilesRenderer.java
@@ -10,10 +10,10 @@ import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.EntityRenderDispatcher;
 import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3f;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.IAnimatableModel;
 import software.bernie.geckolib3.core.controller.AnimationController;
@@ -48,9 +48,9 @@ public class GeoProjectilesRenderer<T extends Entity & IAnimatable> extends Enti
 			VertexConsumerProvider bufferIn, int packedLightIn) {
 		GeoModel model = modelProvider.getModel(modelProvider.getModelLocation(entityIn));
 		matrixStackIn.push();
-		matrixStackIn.multiply(Vector3f.POSITIVE_Y
+		matrixStackIn.multiply(Vec3f.POSITIVE_Y
 				.getDegreesQuaternion(MathHelper.lerp(partialTicks, entityIn.prevYaw, entityIn.yaw) - 90.0F));
-		matrixStackIn.multiply(Vector3f.POSITIVE_Z
+		matrixStackIn.multiply(Vec3f.POSITIVE_Z
 				.getDegreesQuaternion(MathHelper.lerp(partialTicks, entityIn.prevPitch, entityIn.pitch)));
 		MinecraftClient.getInstance().getTextureManager().bindTexture(getTexture(entityIn));
 		Color renderColor = getRenderColor(entityIn, partialTicks, matrixStackIn, bufferIn, null, packedLightIn);

--- a/src/main/java/software/bernie/geckolib3/renderer/geo/GeoReplacedEntityRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderer/geo/GeoReplacedEntityRenderer.java
@@ -17,7 +17,6 @@ import net.minecraft.client.render.entity.EntityRenderDispatcher;
 import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.PlayerModelPart;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityPose;
 import net.minecraft.entity.LivingEntity;
@@ -26,6 +25,7 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3f;
 import software.bernie.geckolib3.compat.PatchouliCompat;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.IAnimatableModel;
@@ -194,7 +194,7 @@ public abstract class GeoReplacedEntityRenderer<T extends IAnimatable> extends E
 			float rotationYaw, float partialTicks) {
 		EntityPose pose = entityLiving.getPose();
 		if (pose != EntityPose.SLEEPING) {
-			matrixStackIn.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(180.0F - rotationYaw));
+			matrixStackIn.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(180.0F - rotationYaw));
 		}
 
 		if (entityLiving.deathTime > 0) {
@@ -205,23 +205,23 @@ public abstract class GeoReplacedEntityRenderer<T extends IAnimatable> extends E
 			}
 
 			matrixStackIn
-					.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(f * this.getDeathMaxRotation(entityLiving)));
+					.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(f * this.getDeathMaxRotation(entityLiving)));
 		} else if (entityLiving.isUsingRiptide()) {
-			matrixStackIn.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(-90.0F - entityLiving.pitch));
+			matrixStackIn.multiply(Vec3f.POSITIVE_X.getDegreesQuaternion(-90.0F - entityLiving.pitch));
 			matrixStackIn.multiply(
-					Vector3f.POSITIVE_Y.getDegreesQuaternion(((float) entityLiving.age + partialTicks) * -75.0F));
+					Vec3f.POSITIVE_Y.getDegreesQuaternion(((float) entityLiving.age + partialTicks) * -75.0F));
 		} else if (pose == EntityPose.SLEEPING) {
 			Direction direction = entityLiving.getSleepingDirection();
 			float f1 = direction != null ? getFacingAngle(direction) : rotationYaw;
-			matrixStackIn.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(f1));
-			matrixStackIn.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(this.getDeathMaxRotation(entityLiving)));
-			matrixStackIn.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(270.0F));
+			matrixStackIn.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(f1));
+			matrixStackIn.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(this.getDeathMaxRotation(entityLiving)));
+			matrixStackIn.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(270.0F));
 		} else if (entityLiving.hasCustomName() || entityLiving instanceof PlayerEntity) {
 			String s = Formatting.strip(entityLiving.getName().getString());
 			if (("Dinnerbone".equals(s) || "Grumm".equals(s)) && (!(entityLiving instanceof PlayerEntity)
 					|| ((PlayerEntity) entityLiving).isPartVisible(PlayerModelPart.CAPE))) {
 				matrixStackIn.translate(0.0D, entityLiving.getHeight() + 0.1F, 0.0D);
-				matrixStackIn.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(180.0F));
+				matrixStackIn.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(180.0F));
 			}
 		}
 

--- a/src/main/java/software/bernie/geckolib3/renderer/geo/IGeoRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderer/geo/IGeoRenderer.java
@@ -4,11 +4,11 @@ import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.client.util.math.Vector3f;
-import net.minecraft.client.util.math.Vector4f;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Matrix3f;
 import net.minecraft.util.math.Matrix4f;
+import net.minecraft.util.math.Vec3f;
+import net.minecraft.util.math.Vector4f;
 import software.bernie.geckolib3.geo.render.built.*;
 import software.bernie.geckolib3.model.provider.GeoModelProvider;
 import software.bernie.geckolib3.util.RenderUtils;
@@ -69,7 +69,7 @@ public interface IGeoRenderer<T> {
 			if (quad == null) {
 				continue;
 			}
-			Vector3f normal = quad.normal.copy();
+			Vec3f normal = quad.normal.copy();
 			normal.transform(matrix3f);
 
 			if ((cube.size.getY() == 0 || cube.size.getZ() == 0) && normal.getX() < 0) {

--- a/src/main/java/software/bernie/geckolib3/resource/GeckoLibCache.java
+++ b/src/main/java/software/bernie/geckolib3/resource/GeckoLibCache.java
@@ -16,7 +16,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import com.eliotlash.molang.MolangParser;
 
 import net.minecraft.resource.ResourceManager;
-import net.minecraft.resource.ResourceReloadListener;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.profiler.Profiler;
 import software.bernie.geckolib3.GeckoLib;

--- a/src/main/java/software/bernie/geckolib3/resource/GeckoLibCache.java
+++ b/src/main/java/software/bernie/geckolib3/resource/GeckoLibCache.java
@@ -10,6 +10,7 @@ import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
+import net.minecraft.resource.ResourceReloader;
 import org.apache.commons.lang3.ArrayUtils;
 
 import com.eliotlash.molang.MolangParser;
@@ -61,9 +62,9 @@ public class GeckoLibCache {
 		return INSTANCE;
 	}
 
-	public CompletableFuture<Void> reload(ResourceReloadListener.Synchronizer stage, ResourceManager resourceManager,
-			Profiler preparationsProfiler, Profiler reloadProfiler, Executor backgroundExecutor,
-			Executor gameExecutor) {
+	public CompletableFuture<Void> reload(ResourceReloader.Synchronizer stage, ResourceManager resourceManager,
+										  Profiler preparationsProfiler, Profiler reloadProfiler, Executor backgroundExecutor,
+										  Executor gameExecutor) {
 		Map<Identifier, AnimationFile> animations = new HashMap<>();
 		Map<Identifier, GeoModel> geoModels = new HashMap<>();
 		return CompletableFuture.allOf(loadResources(backgroundExecutor, resourceManager, "animations",

--- a/src/main/java/software/bernie/geckolib3/util/RenderUtils.java
+++ b/src/main/java/software/bernie/geckolib3/util/RenderUtils.java
@@ -1,19 +1,19 @@
 package software.bernie.geckolib3.util;
 
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.util.math.Quaternion;
+import net.minecraft.util.math.Vec3f;
 import software.bernie.geckolib3.geo.render.built.GeoBone;
 import software.bernie.geckolib3.geo.render.built.GeoCube;
 
 public class RenderUtils {
 	public static void moveToPivot(GeoCube cube, MatrixStack stack) {
-		Vector3f pivot = cube.pivot;
+		Vec3f pivot = cube.pivot;
 		stack.translate(pivot.getX() / 16, pivot.getY() / 16, pivot.getZ() / 16);
 	}
 
 	public static void moveBackFromPivot(GeoCube cube, MatrixStack stack) {
-		Vector3f pivot = cube.pivot;
+		Vec3f pivot = cube.pivot;
 		stack.translate(-pivot.getX() / 16, -pivot.getY() / 16, -pivot.getZ() / 16);
 	}
 
@@ -35,20 +35,20 @@ public class RenderUtils {
 
 	public static void rotate(GeoBone bone, MatrixStack stack) {
 		if (bone.getRotationZ() != 0.0F) {
-			stack.multiply(Vector3f.POSITIVE_Z.getRadialQuaternion(bone.getRotationZ()));
+			stack.multiply(Vec3f.POSITIVE_Z.getRadialQuaternion(bone.getRotationZ()));
 		}
 
 		if (bone.getRotationY() != 0.0F) {
-			stack.multiply(Vector3f.POSITIVE_Y.getRadialQuaternion(bone.getRotationY()));
+			stack.multiply(Vec3f.POSITIVE_Y.getRadialQuaternion(bone.getRotationY()));
 		}
 
 		if (bone.getRotationX() != 0.0F) {
-			stack.multiply(Vector3f.POSITIVE_X.getRadialQuaternion(bone.getRotationX()));
+			stack.multiply(Vec3f.POSITIVE_X.getRadialQuaternion(bone.getRotationX()));
 		}
 	}
 
 	public static void rotate(GeoCube bone, MatrixStack stack) {
-		Vector3f rotation = bone.rotation;
+		Vec3f rotation = bone.rotation;
 
 		stack.multiply(new Quaternion(0, 0, rotation.getZ(), false));
 		stack.multiply(new Quaternion(0, rotation.getY(), 0, false));

--- a/src/main/java/software/bernie/geckolib3/util/VectorUtils.java
+++ b/src/main/java/software/bernie/geckolib3/util/VectorUtils.java
@@ -1,7 +1,7 @@
 package software.bernie.geckolib3.util;
 
 import net.minecraft.client.util.math.Vector3d;
-import net.minecraft.client.util.math.Vector3f;
+import net.minecraft.util.math.Vec3f;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.Validate;
 
@@ -11,16 +11,16 @@ public class VectorUtils {
 		return new Vector3d(array[0], array[1], array[2]);
 	}
 
-	public static Vector3f fromArray(float[] array) {
+	public static Vec3f fromArray(float[] array) {
 		Validate.validIndex(ArrayUtils.toObject(array), 2);
-		return new Vector3f(array[0], array[1], array[2]);
+		return new Vec3f(array[0], array[1], array[2]);
 	}
 
-	public static Vector3f convertDoubleToFloat(Vector3d vector) {
-		return new Vector3f((float) vector.x, (float) vector.y, (float) vector.z);
+	public static Vec3f convertDoubleToFloat(Vector3d vector) {
+		return new Vec3f((float) vector.x, (float) vector.y, (float) vector.z);
 	}
 
-	public static Vector3d convertFloatToDouble(Vector3f vector) {
+	public static Vector3d convertFloatToDouble(Vec3f vector) {
 		return new Vector3d(vector.getX(), vector.getY(), vector.getZ());
 	}
 }

--- a/src/main/java/software/bernie/geckolib3/world/storage/GeckoLibIdTracker.java
+++ b/src/main/java/software/bernie/geckolib3/world/storage/GeckoLibIdTracker.java
@@ -2,7 +2,7 @@ package software.bernie.geckolib3.world.storage;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.world.PersistentState;
 
@@ -22,7 +22,7 @@ public class GeckoLibIdTracker extends PersistentState {
 	}
 
 	@Override
-	public void fromTag(CompoundTag tag) {
+	public void fromTag(NbtCompound tag) {
 		this.usedIds.clear();
 		for (String key : tag.getKeys()) {
 			if (tag.contains(key, 99)) {
@@ -32,7 +32,7 @@ public class GeckoLibIdTracker extends PersistentState {
 	}
 
 	@Override
-	public CompoundTag toTag(CompoundTag tag) {
+	public NbtCompound writeNbt(NbtCompound tag) {
 		for (Object2IntMap.Entry<String> id : this.usedIds.object2IntEntrySet()) {
 			tag.putInt(id.getKey(), id.getIntValue());
 		}


### PR DESCRIPTION
Making GeckoLib compatible with these versions:

**yarn_mappings** 1.16.5+build.3 => 1.16.5+build.10
**loader_version** 0.11.1 => 0.11.6
**fabric_version** 0.29.4+1.16 => 0.36.0+1.16

The main changes here are name changes, specifically Vector3f to Vec3f, MaterialColor to MapColor, CompoundTag to NbtCompound and ResourceReloadListener.Synchronizer to ResourceReloader.Synchronizer. This pr will ensure [AbstractMethodError](https://github.com/bernie-g/geckolib/issues/148) won't be an issue. 

Note, I didn't bump the version in gradle.properties. I presume you will do it if this pr gets accepted.