### PR TITLE
Use FMLEnvironment instead of FMLLoader to determine whether running in production

### DIFF
--- a/src/main/java/software/bernie/example/CommonListener.java
+++ b/src/main/java/software/bernie/example/CommonListener.java
@@ -5,7 +5,7 @@ import net.minecraft.entity.ai.attributes.Attributes;
 import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.loading.FMLLoader;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import software.bernie.example.registry.EntityRegistry;
 import software.bernie.geckolib3.GeckoLib;
 
@@ -13,7 +13,7 @@ import software.bernie.geckolib3.GeckoLib;
 public class CommonListener {
 	@SubscribeEvent
 	public static void registerEntityAttributes(EntityAttributeCreationEvent event) {
-		if (!FMLLoader.isProduction() && !GeckoLibMod.DISABLE_IN_DEV) {
+		if (!FMLEnvironment.production && !GeckoLibMod.DISABLE_IN_DEV) {
 			event.put(EntityRegistry.BIKE_ENTITY.get(),
 					MobEntity.createMobAttributes().add(Attributes.MAX_HEALTH, 1.0D).build());
 			event.put(EntityRegistry.GEO_EXAMPLE_ENTITY.get(),


### PR DESCRIPTION
Currently sometimes `FMLEnvironment` and sometimes `FMLLoader` is used to test whether running in production.

However `FMLEnvironment.production` can also be set to true when the system property `production` is set. With this, it's possible to simulate production in a development environment. Currently setting this system property when GeckloLib is installed will crash with:

```
java.lang.NullPointerException: Registry Object not present: geckolib3:bikeentity
        at java.util.Objects.requireNonNull(Objects.java:290)
        at net.minecraftforge.fml.RegistryObject.get(RegistryObject.java:120)
        at software.bernie.example.CommonListener.registerEntityAttributes(CommonListener.java:17
```

This pull request changes this to always use `FMLEnvironment` so it is possible to use the production system property with GeckoLib.