### PR TITLE
Added a public getter to the geo layer renderer

### DIFF
--- a/src/main/java/software/bernie/geckolib3/renderers/geo/GeoLayerRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/GeoLayerRenderer.java
@@ -48,6 +48,10 @@ public abstract class GeoLayerRenderer<T extends Entity & IAnimatable> {
 	public GeoModelProvider getEntityModel() {
 		return this.entityRenderer.getGeoModelProvider();
 	}
+	
+	public IGeoRenderer<T> getRenderer(){
+		return this.entityRenderer;
+	}
 
 	protected ResourceLocation getEntityTexture(T entityIn) {
 		return this.entityRenderer.getTextureLocation(entityIn);


### PR DESCRIPTION
The getter makes it easier to access the renderer to render model copies with different render types without having to use AnimationUtils.