### PR TITLE
GeoLayerRenderer cleanup

### DIFF
--- a/src/main/java/software/bernie/geckolib3/renderers/geo/GeoLayerRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/GeoLayerRenderer.java
@@ -2,7 +2,6 @@ package software.bernie.geckolib3.renderers.geo;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.vertex.IVertexBuilder;
-
 import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.entity.LivingRenderer;
@@ -12,7 +11,6 @@ import net.minecraft.util.ResourceLocation;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.geo.render.built.GeoModel;
 import software.bernie.geckolib3.model.provider.GeoModelProvider;
-import software.bernie.geckolib3.util.AnimationUtils;
 
 public abstract class GeoLayerRenderer<T extends Entity & IAnimatable> {
 	private final IGeoRenderer<T> entityRenderer;
@@ -21,35 +19,36 @@ public abstract class GeoLayerRenderer<T extends Entity & IAnimatable> {
 		this.entityRenderer = entityRendererIn;
 	}
 
-	protected static <T extends LivingEntity & IAnimatable> void renderCopyModel(GeoModelProvider<T> modelProviderIn,
+	protected void renderCopyModel(GeoModelProvider<T> modelProviderIn,
 			ResourceLocation textureLocationIn, MatrixStack matrixStackIn, IRenderTypeBuffer bufferIn,
 			int packedLightIn, T entityIn, float partialTicks, float red, float green, float blue) {
 		if (!entityIn.isInvisible()) {
-			renderModel(modelProviderIn, textureLocationIn, matrixStackIn, bufferIn, packedLightIn, entityIn,
+			this.renderModel(modelProviderIn, textureLocationIn, matrixStackIn, bufferIn, packedLightIn, entityIn,
 					partialTicks, red, green, blue);
 		}
 	}
 
-	protected static <T extends LivingEntity & IAnimatable> void renderModel(GeoModelProvider<T> modelProviderIn,
+	protected void renderModel(GeoModelProvider<T> modelProviderIn,
 			ResourceLocation textureLocationIn, MatrixStack matrixStackIn, IRenderTypeBuffer bufferIn,
 			int packedLightIn, T entityIn, float partialTicks, float red, float green, float blue) {
-		GeoModel model = modelProviderIn.getModel(modelProviderIn.getModelLocation(entityIn));
-		@SuppressWarnings("unchecked")
-		IGeoRenderer<T> renderer = (IGeoRenderer<T>) AnimationUtils.getRenderer(entityIn);
-		RenderType renderType = getRenderType(textureLocationIn);
-		IVertexBuilder ivertexbuilder = bufferIn.getBuffer(renderType);
-		renderer.render(model, entityIn, partialTicks, renderType, matrixStackIn, bufferIn, ivertexbuilder,
-				packedLightIn, LivingRenderer.getOverlayCoords(entityIn, 0.0F), red, green, blue, 1.0F);
+		if (entityIn instanceof LivingEntity) {
+			GeoModel model = modelProviderIn.getModel(modelProviderIn.getModelLocation(entityIn));
+			RenderType renderType = this.getRenderType(textureLocationIn);
+			IVertexBuilder ivertexbuilder = bufferIn.getBuffer(renderType);
+
+			this.getRenderer().render(model, entityIn, partialTicks, renderType, matrixStackIn, bufferIn, ivertexbuilder,
+					packedLightIn, LivingRenderer.getOverlayCoords((LivingEntity) entityIn, 0.0F), red, green, blue, 1.0F);
+		}
 	}
 
-	public static RenderType getRenderType(ResourceLocation textureLocation) {
+	public RenderType getRenderType(ResourceLocation textureLocation) {
 		return RenderType.entityCutout(textureLocation);
 	}
 
 	public GeoModelProvider<?> getEntityModel() {
 		return this.entityRenderer.getGeoModelProvider();
 	}
-	
+
 	public IGeoRenderer<T> getRenderer(){
 		return this.entityRenderer;
 	}
@@ -59,6 +58,6 @@ public abstract class GeoLayerRenderer<T extends Entity & IAnimatable> {
 	}
 
 	public abstract void render(MatrixStack matrixStackIn, IRenderTypeBuffer bufferIn, int packedLightIn,
-			T entitylivingbaseIn, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks,
+			T entityLivingBaseIn, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks,
 			float netHeadYaw, float headPitch);
 }


### PR DESCRIPTION
Removes the unnecessary use of static methods for the class. This allows using getRenderer() to directly access the entity renderer and avoid abusive use of animation utils.