### PR TITLE
Add standard non-dev jar to publishing artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,7 @@ publishing {
         mavenJava(MavenPublication) {
             artifact shadowJar
             artifact sourcesJar
+            artifact remapJar
             artifactId = project.archives_base_name
         }
     }


### PR DESCRIPTION
**Versions:** all Fabric branches, specifically 1.17 

---
**Issue**
Geckolib currently only publishes a `dev` and `sources` jar. This means it is not possible to `include` Geckolib in a project because the only jar you can pull from the Geckolib repository is one with yarn-mapped names<sup>1</sup>. 

![image](https://user-images.githubusercontent.com/17728338/132963528-8b357229-5522-44de-bb69-004e105b6f54.png)

_Example of mapped code inside the jar_

![image](https://user-images.githubusercontent.com/17728338/132963551-035116f9-7dfa-426e-9a5e-8065662a0726.png)

_Crash when using a mod that includes Geckolib_

![image](https://user-images.githubusercontent.com/17728338/132963583-70f4ba0c-fbd5-4cc1-b29a-4b37a7d840d4.png)

---
**Solution**

By adding a `remapJar` artifact to Geckolib's publications block, a non-dev (& non-mapped) jar will be published alongside the development jar:

![image](https://user-images.githubusercontent.com/17728338/132963614-c9767e14-b3ea-4ff6-a71d-2fe2e5af319e.png)

*Example of the same code now properly unmapped*

![image](https://user-images.githubusercontent.com/17728338/132963623-e6dd4037-0065-4e24-af16-50669b9a5dd9.png)

*Geckolib being run in a production client as an `included` library*:

![image](https://user-images.githubusercontent.com/17728338/132963656-0fd8836e-73b4-4e7a-ac94-e3e8da03fc6b.png)

---
<sup>1This assumes you actually want to allow people to include Geckolib. Some people don't like it because it adds bloat to modpacks & takes Curse Points away from the library maintainers.</sup>

Let me know if you have any questions. Thanks!