### PR TITLE
Fix for render layers being hardcoded to players

### DIFF
--- a/src/main/java/software/bernie/geckolib3/renderers/geo/GeoEntityRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/GeoEntityRenderer.java
@@ -148,7 +148,7 @@ public abstract class GeoEntityRenderer<T extends EntityLivingBase & IAnimatable
 			RenderHurtColor.unset();
 		}
 
-		if (!(entity instanceof Entityplayer) || (entity instanceof EntityPlayer && !((EntityPlayer) entity).isSpectator()))
+		if (!(entity instanceof EntityPlayer) || (entity instanceof EntityPlayer && !((EntityPlayer) entity).isSpectator()))
 		{
 			for (GeoLayerRenderer<T> layerRenderer : this.layerRenderers)
 			{


### PR DESCRIPTION
Change: instanceof Player check was extended with a !(entity instanceof Player) check, that should fix the hardcoding and still remains the security to not render the layer when a player entity is in spectator mode