### PR TITLE
Fix GeoEntityRenderer render buffers

### DIFF
--- a/src/main/java/software/bernie/geckolib3/renderers/geo/GeoEntityRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/GeoEntityRenderer.java
@@ -156,13 +156,23 @@ public abstract class GeoEntityRenderer<T extends LivingEntity & IAnimatable> ex
 		Color renderColor = getRenderColor(entity, partialTicks, stack, bufferIn, null, packedLightIn);
 		RenderType renderType = getRenderType(entity, partialTicks, stack, bufferIn, null, packedLightIn,
 				getTextureLocation(entity));
-		if (!entity.isInvisibleTo(Minecraft.getInstance().player))
-			render(model, entity, partialTicks, renderType, stack, bufferIn,
-					VertexMultiConsumer.create(bufferIn.getBuffer(RenderType.entityGlintDirect()),
-							bufferIn.getBuffer(RenderType.entityTranslucentCull(getTextureLocation(entity)))),
-					packedLightIn, getPackedOverlay(entity, 0), (float) renderColor.getRed() / 255f,
-					(float) renderColor.getGreen() / 255f, (float) renderColor.getBlue() / 255f,
-					(float) renderColor.getAlpha() / 255);
+		if (!entity.isInvisibleTo(Minecraft.getInstance().player)) {
+			VertexConsumer glintBuffer = bufferIn.getBuffer(RenderType.entityGlintDirect());
+			VertexConsumer translucentBuffer = bufferIn.getBuffer(RenderType.entityTranslucentCull(getTextureLocation(entity)));
+
+			if (glintBuffer != translucentBuffer) {
+				render(model, entity, partialTicks, renderType, stack, bufferIn,
+						VertexMultiConsumer.create(glintBuffer, translucentBuffer),
+						packedLightIn, getPackedOverlay(entity, 0), (float) renderColor.getRed() / 255f,
+						(float) renderColor.getGreen() / 255f, (float) renderColor.getBlue() / 255f,
+						(float) renderColor.getAlpha() / 255);
+			} else {
+				render(model, entity, partialTicks, renderType, stack, bufferIn, null, packedLightIn,
+						getPackedOverlay(entity, 0), (float) renderColor.getRed() / 255f,
+						(float) renderColor.getGreen() / 255f, (float) renderColor.getBlue() / 255f,
+						(float) renderColor.getAlpha() / 255);
+			}
+		}
 
 		if (!entity.isSpectator()) {
 			for (GeoLayerRenderer<T> layerRenderer : this.layerRenderers) {


### PR DESCRIPTION
Since https://github.com/bernie-g/geckolib/commit/7b323eaa02755b9c64284767e77bf9b285c3902d GeckoLib creates a custom VertexMultiConsumer for rendering the geo entities 


https://github.com/bernie-g/geckolib/blob/72fec608030883058a4a7a18d462efc7d564fe02/src/main/java/software/bernie/geckolib3/renderers/geo/GeoEntityRenderer.java#L161-L162

The consumer uses **_glintDirect_** and **_translucentCull_** render types buffers, but uses the MultiBufferSource passed on the method to get them.

Mods like CarryOn that want to render entities in their own way, pass incomplete buffer sources to render entities, those buffer sources might not contain the render types that GeckoLib wants to get, causing a default buffer to be returned, and thus throwing a IllegalArgumentException "Duplicate Delegate" when creating the VertexMultiConsumer, It can't contain the same object.


This PR solves the problem by checking the equality both buffers before creating the consumer.