### PR TITLE
[1.18 - Forge] fix(entity-nametag): Respect Minecraft.renderNames

### DIFF
--- a/src/main/java/software/bernie/geckolib3/renderers/geo/GeoEntityRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/GeoEntityRenderer.java
@@ -343,7 +343,7 @@ public abstract class GeoEntityRenderer<T extends LivingEntity & IAnimatable> ex
 		if (d0 >= (double) (f * f)) {
 			return false;
 		} else {
-			return entity == this.entityRenderDispatcher.crosshairPickEntity && entity.hasCustomName();
+			return entity == this.entityRenderDispatcher.crosshairPickEntity && entity.hasCustomName() && Minecraft.renderNames();
 		}
 	}
 


### PR DESCRIPTION
While hovering over the entity, no matter of hiding the GUI the name tag was still showing.