### PR TITLE
[1.19 - Fabric] fix(entity-nametag): Respect Minecraft.renderNames

### DIFF
--- a/src/main/java/software/bernie/geckolib3/renderers/geo/GeoEntityRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/GeoEntityRenderer.java
@@ -334,7 +334,7 @@ public abstract class GeoEntityRenderer<T extends LivingEntity & IAnimatable> ex
 		if (d0 >= (double) (f * f)) {
 			return false;
 		} else {
-			return entity == this.dispatcher.targetedEntity && entity.hasCustomName();
+			return entity == this.dispatcher.targetedEntity && entity.hasCustomName() && MinecraftClient.isHudEnabled();
 		}
 	}
 


### PR DESCRIPTION
1.19 port of #290 