### PR TITLE
[1.16] Update pack.mcmeta

### DIFF
--- a/Forge/src/main/resources/pack.mcmeta
+++ b/Forge/src/main/resources/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
-        "description": "examplemod resources",
-        "pack_format": 5,
+        "description": "Geckolib resources",
+        "pack_format": 6,
         "_comment": "A pack_format of 5 requires json lang files and some texture changes from 1.15. Note: we require v5 pack meta for all mods."
     }
 }


### PR DESCRIPTION
To prevent the the data/resource pack as being highlighted with red.

![image](https://user-images.githubusercontent.com/32039051/192334085-1f1a0604-9813-47a8-a249-5bdf82f76038.png)
