### PR TITLE
Fix set texture for the bone

### DIFF
--- a/Fabric/src/main/java/software/bernie/geckolib3/renderer/geo/ExtendedGeoEntityRenderer.java
+++ b/Fabric/src/main/java/software/bernie/geckolib3/renderer/geo/ExtendedGeoEntityRenderer.java
@@ -466,6 +466,7 @@ public abstract class ExtendedGeoEntityRenderer<T extends LivingEntity & IAnimat
 		}
 
 		super.renderRecursively(bone, stack, bufferIn, packedLightIn, packedOverlayIn, red, green, blue, alpha);
+		bufferIn = rtb.getBuffer(RenderLayer.getEntityTranslucent(currentTexture));
 	}
 
 	/*

--- a/Forge/src/main/java/software/bernie/geckolib3/renderers/geo/ExtendedGeoEntityRenderer.java
+++ b/Forge/src/main/java/software/bernie/geckolib3/renderers/geo/ExtendedGeoEntityRenderer.java
@@ -275,6 +275,7 @@ public abstract class ExtendedGeoEntityRenderer<T extends LivingEntity & IAnimat
 		}
 
 		super.renderRecursively(bone, stack, bufferIn, packedLightIn, packedOverlayIn, red, green, blue, alpha);
+		bufferIn = rtb.getBuffer(RenderType.entityTranslucent(currentTexture));
 	}
 	
 	/*


### PR DESCRIPTION
I noticed that if you use the `getTextureForBone` method to set the texture of a particular bone, then the texture can be superimposed not only on the selected bone, but also on others(example: head, arm, etc.)

With fix:
![with-fix](https://user-images.githubusercontent.com/9529993/192541767-bb45395e-46e0-4e2b-9ec3-14d2a6d2241c.png)

Without fix:
![without-fix](https://user-images.githubusercontent.com/9529993/192541776-02b00b04-e36d-4b68-9d3e-dc8407475b75.png)
