### PR TITLE
Add geckolib.disable_examples system property, deprecate GeckoLibMod.DISABLE_IN_DEV on Fabric/Quilt

### DIFF
--- a/Fabric/src/main/java/software/bernie/example/ClientListener.java
+++ b/Fabric/src/main/java/software/bernie/example/ClientListener.java
@@ -51,7 +51,7 @@ public class ClientListener implements ClientModInitializer {
 
 	@Override
 	public void onInitializeClient() {
-		if (FabricLoader.getInstance().isDevelopmentEnvironment() && !GeckoLibMod.DISABLE_IN_DEV) {
+		if (GeckoLibMod.shouldRegisterExamples()) {
 			EntityRendererRegistry.register(EntityRegistry.GEO_EXAMPLE_ENTITY, ExampleGeoRenderer::new);
 			EntityRendererRegistry.register(EntityRegistry.GEOLAYERENTITY, LERenderer::new);
 			EntityRendererRegistry.register(EntityRegistry.BIKE_ENTITY, BikeGeoRenderer::new);

--- a/Fabric/src/main/java/software/bernie/example/GeckoLibMod.java
+++ b/Fabric/src/main/java/software/bernie/example/GeckoLibMod.java
@@ -12,13 +12,22 @@ import software.bernie.example.registry.*;
 import software.bernie.geckolib3.GeckoLib;
 
 public class GeckoLibMod implements ModInitializer {
+	/**
+	 * When set to true, prevents examples from being registered.
+	 *
+	 * @deprecated due to mod loading order, setting this in your mod may not have an effect.
+	 * Use the {@link #DISABLE_EXAMPLES_PROPERTY_KEY system property} instead.
+	 */
+	@Deprecated(since = "3.1.21")
 	public static boolean DISABLE_IN_DEV = false;
-	boolean isDevelopmentEnvironment = FabricLoader.getInstance().isDevelopmentEnvironment();
+	public static final String DISABLE_EXAMPLES_PROPERTY_KEY = "geckolib.disable_examples";
+	private static final boolean isDevelopmentEnvironment = FabricLoader.getInstance().isDevelopmentEnvironment();
+
 
 	@Override
 	public void onInitialize() {
 		GeckoLib.initialize();
-		if (isDevelopmentEnvironment && !GeckoLibMod.DISABLE_IN_DEV) {
+		if (shouldRegisterExamples()) {
 			new EntityRegistry();
 			FabricDefaultAttributeRegistry.register(EntityRegistry.GEO_EXAMPLE_ENTITY,
 					EntityUtils.createGenericEntityAttributes());
@@ -33,5 +42,19 @@ public class GeckoLibMod implements ModInitializer {
 			new BlockRegistry();
 			new SoundRegistry();
 		}
+	}
+
+	/**
+	 * Returns whether examples are to be registered. Examples are registered when:
+	 * <ul>
+	 *     <li>The mod is running in a development environment; <em>and</em></li>
+	 *     <li>{@link #DISABLE_IN_DEV} is not set to true; <em>and</em></li>
+	 *     <li>the system property defined by {@link #DISABLE_EXAMPLES_PROPERTY_KEY} is not set to "true".</li>
+	 * </ul>
+	 *
+	 * @return whether the examples are to be registered
+	 */
+	static boolean shouldRegisterExamples() {
+		return isDevelopmentEnvironment && !DISABLE_IN_DEV && !Boolean.getBoolean(DISABLE_EXAMPLES_PROPERTY_KEY);
 	}
 }

--- a/Forge/src/main/java/software/bernie/example/ClientListener.java
+++ b/Forge/src/main/java/software/bernie/example/ClientListener.java
@@ -34,7 +34,7 @@ public class ClientListener {
 
 	@SubscribeEvent
 	public static void registerRenderers(final EntityRenderersEvent.RegisterRenderers event) {
-		if (!FMLEnvironment.production && !GeckoLibMod.DISABLE_IN_DEV) {
+		if (GeckoLibMod.shouldRegisterExamples()) {
 			event.registerEntityRenderer(EntityRegistry.GEO_EXAMPLE_ENTITY.get(), ExampleGeoRenderer::new);
 			event.registerEntityRenderer(EntityRegistry.BIKE_ENTITY.get(), BikeGeoRenderer::new);
 			event.registerEntityRenderer(EntityRegistry.GEOLAYERENTITY.get(), LERenderer::new);
@@ -50,14 +50,14 @@ public class ClientListener {
 
 	@SubscribeEvent
 	public static void registerRenderers(final EntityRenderersEvent.AddLayers event) {
-		if (!FMLEnvironment.production && !GeckoLibMod.DISABLE_IN_DEV) {
+		if (GeckoLibMod.shouldRegisterExamples()) {
 			GeoArmorRenderer.registerArmorRenderer(PotatoArmorItem.class, () -> new PotatoArmorRenderer());
 		}
 	}
 
 	@SubscribeEvent
 	public static void registerRenderers(final FMLClientSetupEvent event) {
-		if (!FMLEnvironment.production && !GeckoLibMod.DISABLE_IN_DEV) {
+		if (GeckoLibMod.shouldRegisterExamples()) {
 			ItemBlockRenderTypes.setRenderLayer(BlockRegistry.HABITAT_BLOCK.get(), RenderType.translucent());
 		}
 	}

--- a/Forge/src/main/java/software/bernie/example/GeckoLibMod.java
+++ b/Forge/src/main/java/software/bernie/example/GeckoLibMod.java
@@ -28,7 +28,11 @@ import software.bernie.geckolib3.renderers.geo.GeoArmorRenderer;
 @Mod(GeckoLib.ModID)
 public class GeckoLibMod {
 	public static CreativeModeTab geckolibItemGroup;
+	/**
+	 * When set to true, prevents examples from being registered.
+	 */
 	public static boolean DISABLE_IN_DEV = false;
+	public static final String DISABLE_EXAMPLES_PROPERTY_KEY = "geckolib.disable_examples";
 
 	public GeckoLibMod() {
 		GeckoLib.initialize();
@@ -64,5 +68,20 @@ public class GeckoLibMod {
 					instances.remove(event.getEntity().getUUID());
 				}
 			});
+	}
+
+
+	/**
+	 * Returns whether examples are to be registered. Examples are registered when:
+	 * <ul>
+	 *     <li>The mod is running in a development environment; <em>and</em></li>
+	 *     <li>{@link #DISABLE_IN_DEV} is not set to true; <em>and</em></li>
+	 *     <li>the system property defined by {@link #DISABLE_EXAMPLES_PROPERTY_KEY} is not set to "true".</li>
+	 * </ul>
+	 *
+	 * @return whether the examples are to be registered
+	 */
+	static boolean shouldRegisterExamples() {
+		return !FMLEnvironment.production && !DISABLE_IN_DEV && !Boolean.getBoolean(DISABLE_EXAMPLES_PROPERTY_KEY);
 	}
 }

--- a/Quilt/src/main/java/software/bernie/example/ClientListener.java
+++ b/Quilt/src/main/java/software/bernie/example/ClientListener.java
@@ -53,7 +53,7 @@ public class ClientListener implements ClientModInitializer {
 
 	@Override
 	public void onInitializeClient(ModContainer mod) {
-		if (QuiltLoader.isDevelopmentEnvironment() && !GeckoLibMod.DISABLE_IN_DEV) {
+		if (GeckoLibMod.shouldRegisterExamples()) {
 			EntityRendererRegistry.register(EntityRegistry.GEO_EXAMPLE_ENTITY, ExampleGeoRenderer::new);
 			EntityRendererRegistry.register(EntityRegistry.GEOLAYERENTITY, LERenderer::new);
 			EntityRendererRegistry.register(EntityRegistry.BIKE_ENTITY, BikeGeoRenderer::new);

--- a/Quilt/src/main/java/software/bernie/example/GeckoLibMod.java
+++ b/Quilt/src/main/java/software/bernie/example/GeckoLibMod.java
@@ -18,13 +18,21 @@ import software.bernie.example.registry.TileRegistry;
 import software.bernie.geckolib3.GeckoLib;
 
 public class GeckoLibMod implements ModInitializer {
+	/**
+	 * When set to true, prevents examples from being registered.
+	 *
+	 * @deprecated due to mod loading order, setting this in your mod may not have an effect.
+	 * Use the {@link #DISABLE_EXAMPLES_PROPERTY_KEY system property} instead.
+	 */
+	@Deprecated(since = "3.1.21")
 	public static boolean DISABLE_IN_DEV = false;
-	boolean isDevelopmentEnvironment = QuiltLoader.isDevelopmentEnvironment();
+	public static final String DISABLE_EXAMPLES_PROPERTY_KEY = "geckolib.disable_examples";
+	private static final boolean isDevelopmentEnvironment = QuiltLoader.isDevelopmentEnvironment();
 
 	@Override
 	public void onInitialize(ModContainer mod) {
 		GeckoLib.initialize();
-		if (isDevelopmentEnvironment && !GeckoLibMod.DISABLE_IN_DEV) {
+		if (shouldRegisterExamples()) {
 			new EntityRegistry();
 			FabricDefaultAttributeRegistry.register(EntityRegistry.GEO_EXAMPLE_ENTITY,
 					EntityUtils.createGenericEntityAttributes());
@@ -39,5 +47,19 @@ public class GeckoLibMod implements ModInitializer {
 			new BlockRegistry();
 			new SoundRegistry();
 		}
+	}
+
+	/**
+	 * Returns whether examples are to be registered. Examples are registered when:
+	 * <ul>
+	 *     <li>The mod is running in a development environment; <em>and</em></li>
+	 *     <li>{@link #DISABLE_IN_DEV} is not set to true; <em>and</em></li>
+	 *     <li>the system property defined by {@link #DISABLE_EXAMPLES_PROPERTY_KEY} is not set to "true".</li>
+	 * </ul>
+	 *
+	 * @return whether the examples are to be registered
+	 */
+	static boolean shouldRegisterExamples() {
+		return isDevelopmentEnvironment && !DISABLE_IN_DEV && !Boolean.getBoolean(DISABLE_EXAMPLES_PROPERTY_KEY);
 	}
 }


### PR DESCRIPTION
# Motivation

Due to the arbitrary mod loading order on Fabric and Quilt, mods setting the `GeckolibMod.DISABLE_IN_DEV` field do not always have an effect, as they may be loaded after examples are already registered. Therefore, a system property should be added, which can be set through command line arguments and therefore always apply.

# Content

The PR adds the system property `geckolib.disable_examples`. When set to the string "true", registration of examples is disabled. This is added for all modloaders.

On Quilt and Fabric, `GeckolibMod.DISABLE_IN_DEV` is now deprecated.

# Testing

The changes can be tested by creating a new run config, e.g. by putting this in the `loom` section of `build.gradle`:
```groovy
    runs {
        noExamples {
            inherit client
            name "No Examples"
            vmArg "-Dgeckolib.disable_examples=true"
        }
    }
```