### PR TITLE
Split AnimationFactory into more appropriate objects and move to factory instantiation (Breaking)

### DIFF
--- a/Forge/core/src/main/java/software/bernie/geckolib3/core/manager/AnimationFactory.java
+++ b/Forge/core/src/main/java/software/bernie/geckolib3/core/manager/AnimationFactory.java
@@ -1,33 +1,23 @@
 package software.bernie.geckolib3.core.manager;
 
-import java.util.HashMap;
-
 import software.bernie.geckolib3.core.IAnimatable;
 
-public class AnimationFactory {
-	private final IAnimatable animatable;
-	private HashMap<Integer, AnimationData> animationDataMap = new HashMap<>();
+public abstract class AnimationFactory {
+	protected final IAnimatable animatable;
 
-	public AnimationFactory(IAnimatable animatable) {
+	protected AnimationFactory(IAnimatable animatable) {
 		this.animatable = animatable;
 	}
 
 	/**
 	 * This creates or gets the cached animation manager for any unique ID. For
 	 * itemstacks, this is typically a hashcode of their nbt. For entities it should
-	 * be their unique uuid. For tile entities you can use nbt or just one constant
+	 * be their unique uuid. For block entities you can use nbt or just one constant
 	 * value since they are not singletons.
 	 *
 	 * @param uniqueID A unique integer ID. For every ID the same animation manager
 	 *                 will be returned.
 	 * @return the animatable manager
 	 */
-	public AnimationData getOrCreateAnimationData(Integer uniqueID) {
-		if (!animationDataMap.containsKey(uniqueID)) {
-			AnimationData data = new AnimationData();
-			animatable.registerControllers(data);
-			animationDataMap.put(uniqueID, data);
-		}
-		return animationDataMap.get(uniqueID);
-	}
+	public abstract AnimationData getOrCreateAnimationData(Integer uniqueID);
 }

--- a/Forge/core/src/main/java/software/bernie/geckolib3/core/manager/InstancedAnimationFactory.java
+++ b/Forge/core/src/main/java/software/bernie/geckolib3/core/manager/InstancedAnimationFactory.java
@@ -1,0 +1,25 @@
+package software.bernie.geckolib3.core.manager;
+
+import software.bernie.geckolib3.core.IAnimatable;
+
+/**
+ * AnimationFactory implementation for instantiated objects such as Entities or BlockEntities. Returns a single {@link AnimationData} instance per factory.
+ */
+public class InstancedAnimationFactory extends AnimationFactory {
+	private AnimationData animationData;
+
+	public InstancedAnimationFactory(IAnimatable animatable) {
+		super(animatable);
+	}
+
+	@Override
+	public AnimationData getOrCreateAnimationData(Integer uniqueID) {
+		if (this.animationData == null) {
+			this.animationData = new AnimationData();
+
+			this.animatable.registerControllers(this.animationData);
+		}
+
+		return this.animationData;
+	}
+}

--- a/Forge/core/src/main/java/software/bernie/geckolib3/core/manager/SingletonAnimationFactory.java
+++ b/Forge/core/src/main/java/software/bernie/geckolib3/core/manager/SingletonAnimationFactory.java
@@ -1,0 +1,28 @@
+package software.bernie.geckolib3.core.manager;
+
+import software.bernie.geckolib3.core.IAnimatable;
+
+import java.util.HashMap;
+
+/**
+ * AnimationFactory implementation for singleton/flyweight objects such as Items. Utilises a keyed map to differentiate different instances of the object.
+ */
+public class SingletonAnimationFactory extends AnimationFactory {
+	private final HashMap<Integer, AnimationData> animationDataMap = new HashMap<>();
+
+	public SingletonAnimationFactory(IAnimatable animatable) {
+		super(animatable);
+	}
+
+	@Override
+	public AnimationData getOrCreateAnimationData(Integer uniqueID) {
+		if (!this.animationDataMap.containsKey(uniqueID)) {
+			AnimationData data = new AnimationData();
+
+			this.animatable.registerControllers(data);
+			this.animationDataMap.put(uniqueID, data);
+		}
+
+		return this.animationDataMap.get(uniqueID);
+	}
+}

--- a/Forge/src/main/java/software/bernie/geckolib3/util/GeckoLibUtil.java
+++ b/Forge/src/main/java/software/bernie/geckolib3/util/GeckoLibUtil.java
@@ -1,15 +1,20 @@
 package software.bernie.geckolib3.util;
 
-import static software.bernie.geckolib3.world.storage.GeckoLibIdTracker.Type.ITEM;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import software.bernie.geckolib3.core.IAnimatable;
+import software.bernie.geckolib3.core.controller.AnimationController;
+import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.core.manager.InstancedAnimationFactory;
+import software.bernie.geckolib3.core.manager.SingletonAnimationFactory;
+import software.bernie.geckolib3.world.storage.GeckoLibIdTracker;
 
 import java.util.Objects;
 
-import net.minecraft.nbt.Tag;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.item.ItemStack;
-import software.bernie.geckolib3.core.controller.AnimationController;
-import software.bernie.geckolib3.core.manager.AnimationFactory;
-import software.bernie.geckolib3.world.storage.GeckoLibIdTracker;
+import static software.bernie.geckolib3.world.storage.GeckoLibIdTracker.Type.ITEM;
 
 public class GeckoLibUtil {
 	private static final String GECKO_LIB_ID_NBT = "GeckoLibID";
@@ -80,5 +85,9 @@ public class GeckoLibUtil {
 
 	public static AnimationController getControllerForID(AnimationFactory factory, Integer id, String controllerName) {
 		return factory.getOrCreateAnimationData(id).getAnimationControllers().get(controllerName);
+	}
+
+	public static AnimationFactory createFactory(IAnimatable animatable) {
+		return animatable instanceof Entity || animatable instanceof BlockEntity ? new InstancedAnimationFactory(animatable) : new SingletonAnimationFactory(animatable);
 	}
 }


### PR DESCRIPTION
So obviously I'm fully aware that breaking changes are a problem
So what I'm gonna do is drop the patch files for these into the PR submission so that they can be used at any time

Alternatively, just shelf the PR and keep it in mind for a future time?
Idk man

The summary of this is that it splits up the AnimationFactory into Singleton and Instanced variants, that handle the animationdata differently depending on needs. This allows for skipping of a map retrieval every render frame for entities and other instanced objects

[AnimationFactory_split.zip](https://github.com/bernie-g/geckolib/files/9845677/AnimationFactory_split.zip)
