### PR TITLE
AnimationFactory split

### DIFF
--- a/Forge/core/src/main/java/software/bernie/geckolib3/core/manager/AnimationFactory.java
+++ b/Forge/core/src/main/java/software/bernie/geckolib3/core/manager/AnimationFactory.java
@@ -3,10 +3,23 @@ package software.bernie.geckolib3.core.manager;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import software.bernie.geckolib3.core.IAnimatable;
 
+/**
+ * TODO 1.20+:
+ * <ul>
+ *     <li>Remove {@code animationDataMap}</li>
+ *     <li>Make {@code AnimationFactory} abstract</li>
+ *     <li>Make {@code getOrCreateAnimationData} abstract</li>
+ * </ul>
+ */
 public class AnimationFactory {
-	private final IAnimatable animatable;
+	protected final IAnimatable animatable;
 	private final Int2ObjectOpenHashMap<AnimationData> animationDataMap = new Int2ObjectOpenHashMap<>();
 
+	/**
+	 * Deprecated, use {@code GeckolibUtil#createFactory(IAnimatable)}
+	 * @param animatable The animatable object the factory is for
+	 */
+	@Deprecated
 	public AnimationFactory(IAnimatable animatable) {
 		this.animatable = animatable;
 	}

--- a/Forge/core/src/main/java/software/bernie/geckolib3/core/manager/InstancedAnimationFactory.java
+++ b/Forge/core/src/main/java/software/bernie/geckolib3/core/manager/InstancedAnimationFactory.java
@@ -1,0 +1,25 @@
+package software.bernie.geckolib3.core.manager;
+
+import software.bernie.geckolib3.core.IAnimatable;
+
+/**
+ * AnimationFactory implementation for instantiated objects such as Entities or BlockEntities. Returns a single {@link AnimationData} instance per factory.
+ */
+public class InstancedAnimationFactory extends AnimationFactory {
+	private AnimationData animationData;
+
+	public InstancedAnimationFactory(IAnimatable animatable) {
+		super(animatable);
+	}
+
+	@Override
+	public AnimationData getOrCreateAnimationData(int uniqueID) {
+		if (this.animationData == null) {
+			this.animationData = new AnimationData();
+
+			this.animatable.registerControllers(this.animationData);
+		}
+
+		return this.animationData;
+	}
+}

--- a/Forge/core/src/main/java/software/bernie/geckolib3/core/manager/SingletonAnimationFactory.java
+++ b/Forge/core/src/main/java/software/bernie/geckolib3/core/manager/SingletonAnimationFactory.java
@@ -1,0 +1,27 @@
+package software.bernie.geckolib3.core.manager;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import software.bernie.geckolib3.core.IAnimatable;
+
+/**
+ * AnimationFactory implementation for singleton/flyweight objects such as Items. Utilises a keyed map to differentiate different instances of the object.
+ */
+public class SingletonAnimationFactory extends AnimationFactory {
+	private final Int2ObjectOpenHashMap<AnimationData> animationDataMap = new Int2ObjectOpenHashMap<>();
+
+	public SingletonAnimationFactory(IAnimatable animatable) {
+		super(animatable);
+	}
+
+	@Override
+	public AnimationData getOrCreateAnimationData(int uniqueID) {
+		if (!this.animationDataMap.containsKey(uniqueID)) {
+			AnimationData data = new AnimationData();
+
+			this.animatable.registerControllers(data);
+			this.animationDataMap.put(uniqueID, data);
+		}
+
+		return this.animationDataMap.get(uniqueID);
+	}
+}

--- a/Forge/src/main/java/software/bernie/example/block/tile/FertilizerTileEntity.java
+++ b/Forge/src/main/java/software/bernie/example/block/tile/FertilizerTileEntity.java
@@ -11,9 +11,10 @@ import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 public class FertilizerTileEntity extends BlockEntity implements IAnimatable {
-	private final AnimationFactory manager = new AnimationFactory(this);
+	private final AnimationFactory manager = GeckoLibUtil.createFactory(this);
 
 	private <E extends BlockEntity & IAnimatable> PlayState predicate(AnimationEvent<E> event) {
 		AnimationController controller = event.getController();

--- a/Forge/src/main/java/software/bernie/example/block/tile/HabitatTileEntity.java
+++ b/Forge/src/main/java/software/bernie/example/block/tile/HabitatTileEntity.java
@@ -11,9 +11,10 @@ import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 public class HabitatTileEntity extends BlockEntity implements IAnimatable {
-	private final AnimationFactory factory = new AnimationFactory(this);
+	private final AnimationFactory factory = GeckoLibUtil.createFactory(this);
 
 	private <E extends BlockEntity & IAnimatable> PlayState predicate(AnimationEvent<E> event) {
 		event.getController().transitionLengthTicks = 0;

--- a/Forge/src/main/java/software/bernie/example/entity/BikeEntity.java
+++ b/Forge/src/main/java/software/bernie/example/entity/BikeEntity.java
@@ -1,7 +1,5 @@
 package software.bernie.example.entity;
 
-import javax.annotation.Nullable;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
@@ -22,9 +20,12 @@ import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
+
+import javax.annotation.Nullable;
 
 public class BikeEntity extends Animal implements IAnimatable {
-	private final AnimationFactory factory = new AnimationFactory(this);
+	private final AnimationFactory factory = GeckoLibUtil.createFactory(this);
 
 	private <E extends IAnimatable> PlayState predicate(AnimationEvent<E> event) {
 		event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.bike.idle", true));

--- a/Forge/src/main/java/software/bernie/example/entity/CarEntity.java
+++ b/Forge/src/main/java/software/bernie/example/entity/CarEntity.java
@@ -25,9 +25,10 @@ import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 public class CarEntity extends Animal implements IAnimatable {
-	private final AnimationFactory factory = new AnimationFactory(this);
+	private final AnimationFactory factory = GeckoLibUtil.createFactory(this);
 
 	private <E extends IAnimatable> PlayState predicate(AnimationEvent<E> event) {
 		if (event.isMoving() && this.getFirstPassenger() != null) {

--- a/Forge/src/main/java/software/bernie/example/entity/ExtendedRendererEntity.java
+++ b/Forge/src/main/java/software/bernie/example/entity/ExtendedRendererEntity.java
@@ -1,7 +1,5 @@
 package software.bernie.example.entity;
 
-import java.util.Optional;
-
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.world.InteractionHand;
@@ -11,13 +9,7 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.ai.goal.LookAtPlayerGoal;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ArmorItem;
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.ProjectileWeaponItem;
-import net.minecraft.world.item.ShieldItem;
-import net.minecraft.world.item.UseAnim;
+import net.minecraft.world.item.*;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.AbstractSkullBlock;
 import net.minecraftforge.network.NetworkHooks;
@@ -29,11 +21,14 @@ import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
+
+import java.util.Optional;
 
 public class ExtendedRendererEntity extends PathfinderMob implements IAnimatable {
 
 	// Geckolib
-	private AnimationFactory factory = new AnimationFactory(this);
+	private AnimationFactory factory = GeckoLibUtil.createFactory(this);
 
 	public ExtendedRendererEntity(EntityType<? extends PathfinderMob> p_i48575_1_, Level p_i48575_2_) {
 		super(p_i48575_1_, p_i48575_2_);

--- a/Forge/src/main/java/software/bernie/example/entity/GeoExampleEntity.java
+++ b/Forge/src/main/java/software/bernie/example/entity/GeoExampleEntity.java
@@ -21,9 +21,10 @@ import software.bernie.geckolib3.core.event.CustomInstructionKeyframeEvent;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 public class GeoExampleEntity extends PathfinderMob implements IAnimatable, IAnimationTickable {
-	private AnimationFactory factory = new AnimationFactory(this);
+	private AnimationFactory factory = GeckoLibUtil.createFactory(this);
 	private boolean isAnimating = false;
 
 	public GeoExampleEntity(EntityType<? extends PathfinderMob> type, Level worldIn) {

--- a/Forge/src/main/java/software/bernie/example/entity/LEEntity.java
+++ b/Forge/src/main/java/software/bernie/example/entity/LEEntity.java
@@ -13,9 +13,10 @@ import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 public class LEEntity extends PathfinderMob implements IAnimatable, IAnimationTickable {
-    private AnimationFactory factory = new AnimationFactory(this);
+    private AnimationFactory factory = GeckoLibUtil.createFactory(this);
 
     private <E extends IAnimatable> PlayState predicate(AnimationEvent<E> event) {
             event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.geoLayerEntity.idle", true));

--- a/Forge/src/main/java/software/bernie/example/entity/ReplacedCreeperEntity.java
+++ b/Forge/src/main/java/software/bernie/example/entity/ReplacedCreeperEntity.java
@@ -7,9 +7,10 @@ import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 public class ReplacedCreeperEntity implements IAnimatable {
-	AnimationFactory factory = new AnimationFactory(this);
+	AnimationFactory factory = GeckoLibUtil.createFactory(this);
 
 	@Override
 	public void registerControllers(AnimationData data) {

--- a/Forge/src/main/java/software/bernie/example/entity/TexturePerBoneTestEntity.java
+++ b/Forge/src/main/java/software/bernie/example/entity/TexturePerBoneTestEntity.java
@@ -6,6 +6,7 @@ import net.minecraft.world.level.Level;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 public class TexturePerBoneTestEntity extends PathfinderMob implements IAnimatable {
 
@@ -18,7 +19,7 @@ public class TexturePerBoneTestEntity extends PathfinderMob implements IAnimatab
 		
 	}
 
-	private AnimationFactory factory = new AnimationFactory(this);
+	private AnimationFactory factory = GeckoLibUtil.createFactory(this);
 	
 	@Override
 	public AnimationFactory getFactory() {

--- a/Forge/src/main/java/software/bernie/example/item/GeckoArmorItem.java
+++ b/Forge/src/main/java/software/bernie/example/item/GeckoArmorItem.java
@@ -1,9 +1,5 @@
 package software.bernie.example.item;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.decoration.ArmorStand;
@@ -20,9 +16,14 @@ import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
 import software.bernie.geckolib3.item.GeoArmorItem;
+import software.bernie.geckolib3.util.GeckoLibUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class GeckoArmorItem extends GeoArmorItem implements IAnimatable {
-	private AnimationFactory factory = new AnimationFactory(this);
+	private AnimationFactory factory = GeckoLibUtil.createFactory(this);
 
 	public GeckoArmorItem(ArmorMaterial materialIn, EquipmentSlot slot, Properties builder) {
 		super(materialIn, slot, builder.tab(GeckoLibMod.geckolibItemGroup));

--- a/Forge/src/main/java/software/bernie/example/item/JackInTheBoxItem.java
+++ b/Forge/src/main/java/software/bernie/example/item/JackInTheBoxItem.java
@@ -1,7 +1,5 @@
 package software.bernie.example.item;
 
-import java.util.function.Consumer;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
@@ -31,10 +29,12 @@ import software.bernie.geckolib3.network.GeckoLibNetwork;
 import software.bernie.geckolib3.network.ISyncable;
 import software.bernie.geckolib3.util.GeckoLibUtil;
 
+import java.util.function.Consumer;
+
 public class JackInTheBoxItem extends Item implements IAnimatable, ISyncable {
 	private static final String CONTROLLER_NAME = "popupController";
 	private static final int ANIM_OPEN = 0;
-	public AnimationFactory factory = new AnimationFactory(this);
+	public AnimationFactory factory = GeckoLibUtil.createFactory(this);
 
 	public JackInTheBoxItem(Properties properties) {
 		super(properties.tab(GeckoLibMod.geckolibItemGroup));

--- a/Forge/src/main/java/software/bernie/example/item/PistolItem.java
+++ b/Forge/src/main/java/software/bernie/example/item/PistolItem.java
@@ -1,8 +1,5 @@
 package software.bernie.example.item;
 
-import java.util.List;
-import java.util.function.Consumer;
-
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.network.chat.Component;
@@ -33,9 +30,12 @@ import software.bernie.geckolib3.network.GeckoLibNetwork;
 import software.bernie.geckolib3.network.ISyncable;
 import software.bernie.geckolib3.util.GeckoLibUtil;
 
+import java.util.List;
+import java.util.function.Consumer;
+
 public class PistolItem extends Item implements IAnimatable, ISyncable {
 
-	public AnimationFactory factory = new AnimationFactory(this);
+	public AnimationFactory factory = GeckoLibUtil.createFactory(this);
 	public String controllerName = "controller";
 	public static final int ANIM_OPEN = 0;
 

--- a/Forge/src/main/java/software/bernie/geckolib3/util/GeckoLibUtil.java
+++ b/Forge/src/main/java/software/bernie/geckolib3/util/GeckoLibUtil.java
@@ -2,9 +2,14 @@ package software.bernie.geckolib3.util;
 
 import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.core.manager.InstancedAnimationFactory;
+import software.bernie.geckolib3.core.manager.SingletonAnimationFactory;
 import software.bernie.geckolib3.world.storage.GeckoLibIdTracker;
 
 import java.util.Objects;
@@ -80,5 +85,25 @@ public class GeckoLibUtil {
 
 	public static AnimationController getControllerForID(AnimationFactory factory, Integer id, String controllerName) {
 		return factory.getOrCreateAnimationData(id).getAnimationControllers().get(controllerName);
+	}
+
+	/**
+	 * Creates a new AnimationFactory for the given animatable object
+	 * @param animatable The animatable object
+	 * @return A new AnimationFactory instance
+	 */
+	public static AnimationFactory createFactory(IAnimatable animatable) {
+		return createFactory(animatable, !(animatable instanceof Entity) && !(animatable instanceof BlockEntity));
+	}
+
+	/**
+	 * Creates a new AnimationFactory for the given animatable object. <br>
+	 * Recommended to use {@link GeckoLibUtil#createFactory(IAnimatable)} unless you know what you're doing.
+	 * @param animatable The animatable object
+	 * @param singletonObject Whether the object is a singleton/flyweight object, and uses ints to differentiate animatable instances
+	 * @return A new AnimationFactory instance
+	 */
+	public static AnimationFactory createFactory(IAnimatable animatable, boolean singletonObject) {
+		return singletonObject ? new SingletonAnimationFactory(animatable) : new InstancedAnimationFactory(animatable);
 	}
 }


### PR DESCRIPTION
Should be non-breaking
Marked with deprecation and notes for future changes

Ideally devs would move to the new factory methods for the future, so that factories can properly retrieve AnimationData instances in an efficient manner
Additionally moved the data map to a fastutil unboxing-free map 