### PR TITLE
Move to a safer parser for ILoopType

### DIFF
--- a/Forge/core/src/main/java/software/bernie/geckolib3/core/builder/ILoopType.java
+++ b/Forge/core/src/main/java/software/bernie/geckolib3/core/builder/ILoopType.java
@@ -1,5 +1,7 @@
 package software.bernie.geckolib3.core.builder;
 
+import java.util.Locale;
+
 public interface ILoopType {
 
 	boolean isRepeatingAfterEnd();
@@ -24,5 +26,21 @@ public interface ILoopType {
 			return this.looping;
 		}
 	}
-	
+
+	static ILoopType fromString(String string) {
+		if (string == null || string.equalsIgnoreCase("false")) {
+			return EDefaultLoopTypes.PLAY_ONCE;
+		}
+
+		if (string.equalsIgnoreCase("true")) {
+			return EDefaultLoopTypes.LOOP;
+		}
+
+		try {
+			return EDefaultLoopTypes.valueOf(string.toUpperCase(Locale.ROOT));
+		}
+		catch (Exception ex) {}
+
+		return EDefaultLoopTypes.PLAY_ONCE;
+	}
 }

--- a/Forge/core/src/main/java/software/bernie/geckolib3/core/builder/ILoopType.java
+++ b/Forge/core/src/main/java/software/bernie/geckolib3/core/builder/ILoopType.java
@@ -1,5 +1,8 @@
 package software.bernie.geckolib3.core.builder;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
 import java.util.Locale;
 
 public interface ILoopType {
@@ -27,19 +30,33 @@ public interface ILoopType {
 		}
 	}
 
-	static ILoopType fromString(String string) {
-		if (string == null || string.equalsIgnoreCase("false")) {
+	static ILoopType fromJson(JsonElement json) {
+		if (json == null || !json.isJsonPrimitive()) {
 			return EDefaultLoopTypes.PLAY_ONCE;
 		}
 
-		if (string.equalsIgnoreCase("true")) {
-			return EDefaultLoopTypes.LOOP;
+		JsonPrimitive primitive = json.getAsJsonPrimitive();
+
+		if (primitive.isBoolean()) {
+			return primitive.getAsBoolean() ? EDefaultLoopTypes.LOOP : EDefaultLoopTypes.PLAY_ONCE;
 		}
 
-		try {
-			return EDefaultLoopTypes.valueOf(string.toUpperCase(Locale.ROOT));
+		if (primitive.isString()) {
+			String string = primitive.getAsString();
+
+			if (string.equalsIgnoreCase("false")) {
+				return EDefaultLoopTypes.PLAY_ONCE;
+			}
+
+			if (string.equalsIgnoreCase("true")) {
+				return EDefaultLoopTypes.LOOP;
+			}
+
+			try {
+				return EDefaultLoopTypes.valueOf(string.toUpperCase(Locale.ROOT));
+			}
+			catch (Exception ex) {}
 		}
-		catch (Exception ex) {}
 
 		return EDefaultLoopTypes.PLAY_ONCE;
 	}

--- a/Forge/src/main/java/software/bernie/geckolib3/util/json/JsonAnimationUtils.java
+++ b/Forge/src/main/java/software/bernie/geckolib3/util/json/JsonAnimationUtils.java
@@ -214,8 +214,7 @@ public class JsonAnimationUtils {
 		animation.animationLength = animationLength == null ? -1
 				: AnimationUtils.convertSecondsToTicks(animationLength.getAsDouble());
 		animation.boneAnimations = new ObjectArrayList<>();
-		JsonElement loop = animationJsonObject.get("loop");
-		animation.loop = ILoopType.fromJson(loop);
+		animation.loop = ILoopType.fromJson(animationJsonObject.get("loop"));
 
 		// Handle parsing sound effect keyframes
 		for (Map.Entry<String, JsonElement> keyFrame : getSoundEffectFrames(animationJsonObject)) {

--- a/Forge/src/main/java/software/bernie/geckolib3/util/json/JsonAnimationUtils.java
+++ b/Forge/src/main/java/software/bernie/geckolib3/util/json/JsonAnimationUtils.java
@@ -12,7 +12,6 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.server.ChainedJsonException;
 import software.bernie.geckolib3.core.builder.Animation;
 import software.bernie.geckolib3.core.builder.ILoopType;
-import software.bernie.geckolib3.core.builder.ILoopType.EDefaultLoopTypes;
 import software.bernie.geckolib3.core.keyframe.BoneAnimation;
 import software.bernie.geckolib3.core.keyframe.EventKeyFrame;
 import software.bernie.geckolib3.core.keyframe.ParticleEventKeyFrame;
@@ -216,7 +215,7 @@ public class JsonAnimationUtils {
 				: AnimationUtils.convertSecondsToTicks(animationLength.getAsDouble());
 		animation.boneAnimations = new ObjectArrayList<>();
 		JsonElement loop = animationJsonObject.get("loop");
-		animation.loop = loop == null ? EDefaultLoopTypes.PLAY_ONCE : ILoopType.fromString(loop.getAsString());
+		animation.loop = ILoopType.fromJson(loop);
 
 		// Handle parsing sound effect keyframes
 		for (Map.Entry<String, JsonElement> keyFrame : getSoundEffectFrames(animationJsonObject)) {

--- a/Forge/src/main/java/software/bernie/geckolib3/util/json/JsonAnimationUtils.java
+++ b/Forge/src/main/java/software/bernie/geckolib3/util/json/JsonAnimationUtils.java
@@ -11,6 +11,7 @@ import com.google.gson.*;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.server.ChainedJsonException;
 import software.bernie.geckolib3.core.builder.Animation;
+import software.bernie.geckolib3.core.builder.ILoopType;
 import software.bernie.geckolib3.core.builder.ILoopType.EDefaultLoopTypes;
 import software.bernie.geckolib3.core.keyframe.BoneAnimation;
 import software.bernie.geckolib3.core.keyframe.EventKeyFrame;
@@ -215,9 +216,7 @@ public class JsonAnimationUtils {
 				: AnimationUtils.convertSecondsToTicks(animationLength.getAsDouble());
 		animation.boneAnimations = new ObjectArrayList<>();
 		JsonElement loop = animationJsonObject.get("loop");
-		animation.loop = loop == null ? EDefaultLoopTypes.PLAY_ONCE
-				: EDefaultLoopTypes.valueOf(loop.getAsString() == "true" ? EDefaultLoopTypes.LOOP.toString()
-						: loop.getAsString().toUpperCase());
+		animation.loop = loop == null ? EDefaultLoopTypes.PLAY_ONCE : ILoopType.fromString(loop.getAsString());
 
 		// Handle parsing sound effect keyframes
 		for (Map.Entry<String, JsonElement> keyFrame : getSoundEffectFrames(animationJsonObject)) {


### PR DESCRIPTION
Move to a better/safer parsing for ILoopType from json
This should resolve https://github.com/bernie-g/geckolib/issues/316, but is also just better in general and should be done regardless