### PR TITLE
Use generic type instead of BlockEntity when overriding BlockEntityRenderer#render

### DIFF
--- a/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoBlockRenderer.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoBlockRenderer.java
@@ -121,9 +121,9 @@ public class GeoBlockRenderer<T extends BlockEntity & GeoAnimatable> implements 
 	}
 
 	@Override
-	public void render(BlockEntity animatable, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource,
+	public void render(T animatable, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource,
 			int packedLight, int packedOverlay) {
-		this.animatable = (T)animatable;
+		this.animatable = animatable;
 
 		defaultRender(poseStack, this.animatable, bufferSource, null, null, 0, partialTick, packedLight);
 	}

--- a/Forge/src/main/java/software/bernie/geckolib/renderer/GeoBlockRenderer.java
+++ b/Forge/src/main/java/software/bernie/geckolib/renderer/GeoBlockRenderer.java
@@ -122,9 +122,9 @@ public class GeoBlockRenderer<T extends BlockEntity & GeoAnimatable> implements 
 	}
 
 	@Override
-	public void render(BlockEntity animatable, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource,
+	public void render(T animatable, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource,
 			int packedLight, int packedOverlay) {
-		this.animatable = (T)animatable;
+		this.animatable = animatable;
 
 		defaultRender(poseStack, this.animatable, bufferSource, null, null, 0, partialTick, packedLight);
 	}


### PR DESCRIPTION
`GeoBlockRenderer` currently overrides `BlockEntityRenderer#render` with a parameter of type `BlockEntity`. The base method, however, uses the generic type `T` for that parameter, so subclasses for a specific class of block entities can use a more specific parameter type. When extending `GeoBlockRenderer`, this is currently not possible, as `GeoBlockRenderer` widens the parameter type to `BlockEntity` no matter what the actual type `T` is.

Actually, it is impossible to override the `render` method at all if the erasure of the type `T` is not `BlockEntity` (i.e. if you put any other upper type bound than `BlockEntity`). Then you can't use your concrete value of `T` as parameter type as explained above. However, you also can't use `BlockEntity` as parameter type as in that case the `render` method that tries to override `GeoBlockRenderer` no longer has a sub-signature of the base method (See [JLS 8.4.8.1](https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.4.8.1)). So in either case you'll get a compiler error that prevents overriding the `render` method.

This pull request fixes these problems by using `T` as the parameter type in `GeoBlockRenderer#render`.