### PR TITLE
GeoReplaceEntity enhancements.

### DIFF
--- a/Fabric/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -8,6 +8,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
 import software.bernie.geckolib.GeckoLibException;
+import software.bernie.geckolib.animatable.GeoReplacedEntity;
 import software.bernie.geckolib.cache.GeckoLibCache;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.cache.object.GeoBone;
@@ -141,7 +142,8 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 		if (animatableManager.getFirstTickTime() == -1)
 			animatableManager.startedAt(currentTick + mc.getFrameTime());
 
-		double currentFrameTime = animatable instanceof Entity ? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
+		double currentFrameTime = animatable instanceof Entity || animatable instanceof GeoReplacedEntity
+				? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
 		boolean isReRender = !animatableManager.isFirstTick() && currentFrameTime == animatableManager.getLastUpdateTime();
 
 		if (isReRender && instanceId == this.lastRenderedInstance)

--- a/Fabric/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -161,7 +161,7 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 		this.lastRenderedInstance = instanceId;
 		AnimationProcessor<T> processor = getAnimationProcessor();
 
-		processor.preAnimationSetup(animationState.getAnimatable(), this.animTime);
+		processor.preAnimationSetup(animationState.getAnimatable(), animationState, this.animTime);
 
 		if (!processor.getRegisteredBones().isEmpty())
 			processor.tickAnimation(animatable, this, animatableManager, this.animTime, animationState, crashIfBoneMissing());
@@ -170,7 +170,7 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 	}
 
 	@Override
-	public void applyMolangQueries(T animatable, double animTime) {
+	public void applyMolangQueries(T animatable, AnimationState<T>  animationState, double animTime) {
 		MolangParser parser = MolangParser.INSTANCE;
 		Minecraft mc = Minecraft.getInstance();
 

--- a/Forge/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/Forge/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -8,6 +8,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
 import software.bernie.geckolib.GeckoLibException;
+import software.bernie.geckolib.animatable.GeoReplacedEntity;
 import software.bernie.geckolib.cache.GeckoLibCache;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.cache.object.GeoBone;
@@ -141,7 +142,8 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 		if (animatableManager.getFirstTickTime() == -1)
 			animatableManager.startedAt(currentTick + mc.getFrameTime());
 
-		double currentFrameTime = animatable instanceof Entity ? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
+		double currentFrameTime = animatable instanceof Entity || animatable instanceof GeoReplacedEntity
+				? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
 		boolean isReRender = !animatableManager.isFirstTick() && currentFrameTime == animatableManager.getLastUpdateTime();
 
 		if (isReRender && instanceId == this.lastRenderedInstance)

--- a/Forge/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/Forge/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -179,23 +179,32 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 		parser.setMemoizedValue(MolangQueries.TIME_OF_DAY, () -> mc.level.getDayTime() / 24000f);
 		parser.setMemoizedValue(MolangQueries.MOON_PHASE, mc.level::getMoonPhase);
 
-		if (animatable instanceof Entity entity) {
-			parser.setMemoizedValue(MolangQueries.DISTANCE_FROM_CAMERA, () -> mc.gameRenderer.getMainCamera().getPosition().distanceTo(entity.position()));
-			parser.setMemoizedValue(MolangQueries.IS_ON_GROUND, () -> RenderUtils.booleanToFloat(entity.onGround()));
-			parser.setMemoizedValue(MolangQueries.IS_IN_WATER, () -> RenderUtils.booleanToFloat(entity.isInWater()));
-			parser.setMemoizedValue(MolangQueries.IS_IN_WATER_OR_RAIN, () -> RenderUtils.booleanToFloat(entity.isInWaterRainOrBubble()));
-
-			if (entity instanceof LivingEntity livingEntity) {
-				parser.setMemoizedValue(MolangQueries.HEALTH, livingEntity::getHealth);
-				parser.setMemoizedValue(MolangQueries.MAX_HEALTH, livingEntity::getMaxHealth);
-				parser.setMemoizedValue(MolangQueries.IS_ON_FIRE, () -> RenderUtils.booleanToFloat(livingEntity.isOnFire()));
-				parser.setMemoizedValue(MolangQueries.GROUND_SPEED, () -> {
-					Vec3 velocity = livingEntity.getDeltaMovement();
-
-					return Mth.sqrt((float) ((velocity.x * velocity.x) + (velocity.z * velocity.z)));
-				});
-				parser.setMemoizedValue(MolangQueries.YAW_SPEED, () -> livingEntity.getViewYRot((float)animTime - livingEntity.getViewYRot((float)animTime - 0.1f)));
-			}
+		if (animatable instanceof GeoReplacedEntity) {
+            this.applyMolangEntityQueries(mc, parser, animationState,
+                    animationState.getData(DataTickets.ENTITY), animTime);
+		} else if (animatable instanceof Entity entity) {
+            this.applyMolangEntityQueries(mc, parser, animationState, entity, animTime);
 		}
 	}
+
+    private void applyMolangEntityQueries(Minecraft mc, MolangParser parser, AnimationState<T> animationState,
+                                              Entity entity, double animTime) {
+        parser.setMemoizedValue(MolangQueries.DISTANCE_FROM_CAMERA, () -> mc.gameRenderer.getMainCamera()
+                .getPosition().distanceTo(entity.position()));
+        parser.setMemoizedValue(MolangQueries.IS_ON_GROUND, () -> RenderUtils.booleanToFloat(entity.onGround()));
+        parser.setMemoizedValue(MolangQueries.IS_IN_WATER, () -> RenderUtils.booleanToFloat(entity.isInWater()));
+        parser.setMemoizedValue(MolangQueries.IS_IN_WATER_OR_RAIN, () -> RenderUtils.booleanToFloat(entity.isInWaterRainOrBubble()));
+
+        if (entity instanceof LivingEntity livingEntity) {
+            parser.setMemoizedValue(MolangQueries.HEALTH, livingEntity::getHealth);
+            parser.setMemoizedValue(MolangQueries.MAX_HEALTH, livingEntity::getMaxHealth);
+            parser.setMemoizedValue(MolangQueries.IS_ON_FIRE, () -> RenderUtils.booleanToFloat(livingEntity.isOnFire()));
+            parser.setMemoizedValue(MolangQueries.GROUND_SPEED, () -> {
+                Vec3 velocity = livingEntity.getDeltaMovement();
+                return Mth.sqrt((float) ((velocity.x * velocity.x) + (velocity.z * velocity.z)));
+            });
+            parser.setMemoizedValue(MolangQueries.YAW_SPEED, () ->
+                    livingEntity.getViewYRot((float)animTime - livingEntity.getViewYRot((float)animTime - 0.1f)));
+        }
+    }
 }

--- a/Forge/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/Forge/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -161,7 +161,7 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 		this.lastRenderedInstance = instanceId;
 		AnimationProcessor<T> processor = getAnimationProcessor();
 
-		processor.preAnimationSetup(animationState.getAnimatable(), this.animTime);
+		processor.preAnimationSetup(animationState.getAnimatable(), animationState, this.animTime);
 
 		if (!processor.getRegisteredBones().isEmpty())
 			processor.tickAnimation(animatable, this, animatableManager, this.animTime, animationState, crashIfBoneMissing());
@@ -170,7 +170,7 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 	}
 
 	@Override
-	public void applyMolangQueries(T animatable, double animTime) {
+	public void applyMolangQueries(T animatable, AnimationState<T> animationState, double animTime) {
 		MolangParser parser = MolangParser.INSTANCE;
 		Minecraft mc = Minecraft.getInstance();
 

--- a/NeoForge/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -8,6 +8,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
 import software.bernie.geckolib.GeckoLibException;
+import software.bernie.geckolib.animatable.GeoReplacedEntity;
 import software.bernie.geckolib.cache.GeckoLibCache;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.cache.object.GeoBone;
@@ -141,7 +142,8 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 		if (animatableManager.getFirstTickTime() == -1)
 			animatableManager.startedAt(currentTick + mc.getFrameTime());
 
-		double currentFrameTime = animatable instanceof Entity ? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
+		double currentFrameTime = animatable instanceof Entity || animatable instanceof GeoReplacedEntity
+				? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
 		boolean isReRender = !animatableManager.isFirstTick() && currentFrameTime == animatableManager.getLastUpdateTime();
 
 		if (isReRender && instanceId == this.lastRenderedInstance)

--- a/NeoForge/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -179,23 +179,32 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 		parser.setMemoizedValue(MolangQueries.TIME_OF_DAY, () -> mc.level.getDayTime() / 24000f);
 		parser.setMemoizedValue(MolangQueries.MOON_PHASE, mc.level::getMoonPhase);
 
-		if (animatable instanceof Entity entity) {
-			parser.setMemoizedValue(MolangQueries.DISTANCE_FROM_CAMERA, () -> mc.gameRenderer.getMainCamera().getPosition().distanceTo(entity.position()));
-			parser.setMemoizedValue(MolangQueries.IS_ON_GROUND, () -> RenderUtils.booleanToFloat(entity.onGround()));
-			parser.setMemoizedValue(MolangQueries.IS_IN_WATER, () -> RenderUtils.booleanToFloat(entity.isInWater()));
-			parser.setMemoizedValue(MolangQueries.IS_IN_WATER_OR_RAIN, () -> RenderUtils.booleanToFloat(entity.isInWaterRainOrBubble()));
+		if (animatable instanceof GeoReplacedEntity) {
+			this.applyMolangEntityQueries(mc, parser, animationState,
+					animationState.getData(DataTickets.ENTITY), animTime);
+		} else if (animatable instanceof Entity entity) {
+			this.applyMolangEntityQueries(mc, parser, animationState, entity, animTime);
+		}
+	}
 
-			if (entity instanceof LivingEntity livingEntity) {
-				parser.setMemoizedValue(MolangQueries.HEALTH, livingEntity::getHealth);
-				parser.setMemoizedValue(MolangQueries.MAX_HEALTH, livingEntity::getMaxHealth);
-				parser.setMemoizedValue(MolangQueries.IS_ON_FIRE, () -> RenderUtils.booleanToFloat(livingEntity.isOnFire()));
-				parser.setMemoizedValue(MolangQueries.GROUND_SPEED, () -> {
-					Vec3 velocity = livingEntity.getDeltaMovement();
+	private void applyMolangEntityQueries(Minecraft mc, MolangParser parser, AnimationState<T> animationState,
+										  Entity entity, double animTime) {
+		parser.setMemoizedValue(MolangQueries.DISTANCE_FROM_CAMERA, () -> mc.gameRenderer.getMainCamera()
+				.getPosition().distanceTo(entity.position()));
+		parser.setMemoizedValue(MolangQueries.IS_ON_GROUND, () -> RenderUtils.booleanToFloat(entity.onGround()));
+		parser.setMemoizedValue(MolangQueries.IS_IN_WATER, () -> RenderUtils.booleanToFloat(entity.isInWater()));
+		parser.setMemoizedValue(MolangQueries.IS_IN_WATER_OR_RAIN, () -> RenderUtils.booleanToFloat(entity.isInWaterRainOrBubble()));
 
-					return Mth.sqrt((float) ((velocity.x * velocity.x) + (velocity.z * velocity.z)));
-				});
-				parser.setMemoizedValue(MolangQueries.YAW_SPEED, () -> livingEntity.getViewYRot((float)animTime - livingEntity.getViewYRot((float)animTime - 0.1f)));
-			}
+		if (entity instanceof LivingEntity livingEntity) {
+			parser.setMemoizedValue(MolangQueries.HEALTH, livingEntity::getHealth);
+			parser.setMemoizedValue(MolangQueries.MAX_HEALTH, livingEntity::getMaxHealth);
+			parser.setMemoizedValue(MolangQueries.IS_ON_FIRE, () -> RenderUtils.booleanToFloat(livingEntity.isOnFire()));
+			parser.setMemoizedValue(MolangQueries.GROUND_SPEED, () -> {
+				Vec3 velocity = livingEntity.getDeltaMovement();
+				return Mth.sqrt((float) ((velocity.x * velocity.x) + (velocity.z * velocity.z)));
+			});
+			parser.setMemoizedValue(MolangQueries.YAW_SPEED, () ->
+					livingEntity.getViewYRot((float)animTime - livingEntity.getViewYRot((float)animTime - 0.1f)));
 		}
 	}
 }

--- a/NeoForge/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -161,7 +161,7 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 		this.lastRenderedInstance = instanceId;
 		AnimationProcessor<T> processor = getAnimationProcessor();
 
-		processor.preAnimationSetup(animationState.getAnimatable(), this.animTime);
+		processor.preAnimationSetup(animationState.getAnimatable(), animationState, this.animTime);
 
 		if (!processor.getRegisteredBones().isEmpty())
 			processor.tickAnimation(animatable, this, animatableManager, this.animTime, animationState, crashIfBoneMissing());
@@ -170,7 +170,7 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 	}
 
 	@Override
-	public void applyMolangQueries(T animatable, double animTime) {
+	public void applyMolangQueries(T animatable, AnimationState<T> animationState, double animTime) {
 		MolangParser parser = MolangParser.INSTANCE;
 		Minecraft mc = Minecraft.getInstance();
 

--- a/core/src/main/java/software/bernie/geckolib/core/animatable/model/CoreGeoModel.java
+++ b/core/src/main/java/software/bernie/geckolib/core/animatable/model/CoreGeoModel.java
@@ -61,7 +61,8 @@ public interface CoreGeoModel<E extends GeoAnimatable> {
 	 * This method is called once per render frame for each {@link GeoAnimatable} being rendered.<br>
 	 * Is generally overridden by default to apply the builtin queries, but can be extended further for custom query handling.
 	 * @param animatable The {@code GeoAnimatable} instance currently being rendered
+     * @param animationState The {@code AnimationState} instance of the current animatable being rendered
 	 * @param animTime The internal tick counter kept by the {@link software.bernie.geckolib.core.animation.AnimatableManager manager} for this animatable
 	 */
-	default void applyMolangQueries(E animatable, double animTime) {}
+	default void applyMolangQueries(E animatable, AnimationState<E> animationState, double animTime) {}
 }

--- a/core/src/main/java/software/bernie/geckolib/core/animation/AnimationProcessor.java
+++ b/core/src/main/java/software/bernie/geckolib/core/animation/AnimationProcessor.java
@@ -256,8 +256,8 @@ public class AnimationProcessor<T extends GeoAnimatable> {
 	/**
 	 * Apply transformations and settings prior to acting on any animation-related functionality
 	 */
-	public void preAnimationSetup(T animatable, double animTime) {
-		this.model.applyMolangQueries(animatable, animTime);
+	public void preAnimationSetup(T animatable, AnimationState<T> animationState, double animTime) {
+		this.model.applyMolangQueries(animatable, animationState, animTime);
 	}
 
 	/**


### PR DESCRIPTION
This Pull Request aims to fix various issues with animatables that uses GeoReplaceEntity.

The following changes has been made:

- Added OR statement for GeoReplacedEntity on `GeoModel#handleAnimations` to fix model/animations jittering due to a wrong `currentFrameTime` calculation being used.
- `AnimationState` is now passed as a parameter on `GeoModel#applyMolangQueries` so we can be able to get the current `Entity` instance and parse MoLang values correctly.
- Added `protected` method `GeoModel#applyMolangEntityQueries` so we can strip the entity values parsing logic into a reusable method.

Tested as working with the various example entities in-game and with a Custom Replaced Zombie Entity, no issues noticed.