### PR TITLE
fix: GeoReplaceEntity animation/model jittering.

### DIFF
--- a/Fabric/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -8,6 +8,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
 import software.bernie.geckolib.GeckoLibException;
+import software.bernie.geckolib.animatable.GeoReplacedEntity;
 import software.bernie.geckolib.cache.GeckoLibCache;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.cache.object.GeoBone;
@@ -141,7 +142,8 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 		if (animatableManager.getFirstTickTime() == -1)
 			animatableManager.startedAt(currentTick + mc.getFrameTime());
 
-		double currentFrameTime = animatable instanceof Entity ? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
+		double currentFrameTime = animatable instanceof Entity || animatable instanceof GeoReplacedEntity
+				? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
 		boolean isReRender = !animatableManager.isFirstTick() && currentFrameTime == animatableManager.getLastUpdateTime();
 
 		if (isReRender && instanceId == this.lastRenderedInstance)

--- a/Forge/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/Forge/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -8,6 +8,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
 import software.bernie.geckolib.GeckoLibException;
+import software.bernie.geckolib.animatable.GeoReplacedEntity;
 import software.bernie.geckolib.cache.GeckoLibCache;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.cache.object.GeoBone;
@@ -141,7 +142,8 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 		if (animatableManager.getFirstTickTime() == -1)
 			animatableManager.startedAt(currentTick + mc.getFrameTime());
 
-		double currentFrameTime = animatable instanceof Entity ? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
+		double currentFrameTime = animatable instanceof Entity || animatable instanceof GeoReplacedEntity
+				? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
 		boolean isReRender = !animatableManager.isFirstTick() && currentFrameTime == animatableManager.getLastUpdateTime();
 
 		if (isReRender && instanceId == this.lastRenderedInstance)

--- a/NeoForge/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -8,6 +8,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
 import software.bernie.geckolib.GeckoLibException;
+import software.bernie.geckolib.animatable.GeoReplacedEntity;
 import software.bernie.geckolib.cache.GeckoLibCache;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.cache.object.GeoBone;
@@ -141,7 +142,8 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 		if (animatableManager.getFirstTickTime() == -1)
 			animatableManager.startedAt(currentTick + mc.getFrameTime());
 
-		double currentFrameTime = animatable instanceof Entity ? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
+		double currentFrameTime = animatable instanceof Entity || animatable instanceof GeoReplacedEntity
+				? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
 		boolean isReRender = !animatableManager.isFirstTick() && currentFrameTime == animatableManager.getLastUpdateTime();
 
 		if (isReRender && instanceId == this.lastRenderedInstance)


### PR DESCRIPTION
This Pull Request aims to fix a animation/model jittering while using animatables with `GeoReplacedEntity`.

The following change has been made:

- Added `OR` statement for `GeoReplacedEntity` on `GeoModel#handleAnimations` to fix model/animations jittering due to a wrong currentFrameTime calculation being used.

Tested as working with the various example entities in-game and with a Custom Replaced Zombie Entity, no issues noticed.