### PR TITLE
Set up lighting before getting VertexConsumer

### DIFF
--- a/common/src/main/java/software/bernie/geckolib/renderer/GeoItemRenderer.java
+++ b/common/src/main/java/software/bernie/geckolib/renderer/GeoItemRenderer.java
@@ -193,13 +193,6 @@ public class GeoItemRenderer<T extends Item & GeoAnimatable> extends BlockEntity
 	 */
 	protected void renderInGui(ItemDisplayContext transformType, PoseStack poseStack,
 							   MultiBufferSource bufferSource, int packedLight, int packedOverlay) {
-		MultiBufferSource.BufferSource defaultBufferSource = bufferSource instanceof MultiBufferSource.BufferSource bufferSource2 ?
-				bufferSource2 : Minecraft.getInstance().levelRenderer.renderBuffers.bufferSource();
-		RenderType renderType = getRenderType(this.animatable, getTextureLocation(this.animatable), defaultBufferSource, Minecraft.getInstance().getFrameTime());
-		VertexConsumer buffer = ItemRenderer.getFoilBufferDirect(bufferSource, renderType, true, this.currentItemStack != null && this.currentItemStack.hasFoil());
-
-		poseStack.pushPose();
-
 		if (this.useEntityGuiLighting) {
 			Lighting.setupForEntityInInventory();
 		}
@@ -207,6 +200,12 @@ public class GeoItemRenderer<T extends Item & GeoAnimatable> extends BlockEntity
 			Lighting.setupForFlatItems();
 		}
 
+		MultiBufferSource.BufferSource defaultBufferSource = bufferSource instanceof MultiBufferSource.BufferSource bufferSource2 ?
+				bufferSource2 : Minecraft.getInstance().levelRenderer.renderBuffers.bufferSource();
+		RenderType renderType = getRenderType(this.animatable, getTextureLocation(this.animatable), defaultBufferSource, Minecraft.getInstance().getFrameTime());
+		VertexConsumer buffer = ItemRenderer.getFoilBufferDirect(bufferSource, renderType, true, this.currentItemStack != null && this.currentItemStack.hasFoil());
+
+		poseStack.pushPose();
 		defaultRender(poseStack, this.animatable, defaultBufferSource, renderType, buffer,
 				0, Minecraft.getInstance().getFrameTime(), packedLight);
 		defaultBufferSource.endBatch();


### PR DESCRIPTION
This PR modifies the GeoItemRenderer to set up lighting state before getting the VertexConsumer from the BufferSource. This allows other mods to access the correct lighting state when creating a VertexConsumer for rendering the item.

Helps to fix https://github.com/RaphiMC/ImmediatelyFast/issues/220