### PR TITLE
Fix Forge compatibility

### DIFF
--- a/forge/src/main/java/software/bernie/geckolib/network/GeckoLibNetworkingForge.java
+++ b/forge/src/main/java/software/bernie/geckolib/network/GeckoLibNetworkingForge.java
@@ -22,7 +22,7 @@ import software.bernie.geckolib.util.ClientUtil;
  * Forge service implementation for GeckoLib's networking functionalities
  */
 public final class GeckoLibNetworkingForge implements GeckoLibNetworking {
-    public static PayloadProtocol<RegistryFriendlyByteBuf, CustomPacketPayload> NETWORK_CHANNEL_BUILDER = ChannelBuilder.named(new ResourceLocation(GeckoLibConstants.MODID, "main")).optional().networkProtocolVersion(1).payloadChannel().play();
+    public static PayloadProtocol<RegistryFriendlyByteBuf, CustomPacketPayload> NETWORK_CHANNEL_BUILDER = ChannelBuilder.named(new ResourceLocation(GeckoLibConstants.MODID, "main")).networkProtocolVersion(1).optional().payloadChannel().play();
     public static Channel<CustomPacketPayload> CHANNEL;
 
     public static void init() {


### PR DESCRIPTION
This moves the networkProtocolVersion call before the optional call which allows Forge clients to connect to servers. 

The reason this needs to go first is because the optional call uses the default value for the network protocol version, which is 0, and then the following network protocol version doesn't update (or wipe) the previously assigned network acceptance tests.

![image](https://github.com/bernie-g/geckolib/assets/33832062/4ea9025c-d46f-4a52-96aa-a94534639eef)

Not sure if there's anything else to test to ensure this is working on Forge 1.20.6