### PR TITLE
Fix nested functions being parsed in Molang. Closes #598

### DIFF
--- a/common/src/main/java/software/bernie/geckolib/loading/math/MathParser.java
+++ b/common/src/main/java/software/bernie/geckolib/loading/math/MathParser.java
@@ -321,7 +321,7 @@ public class MathParser {
                     else if (groupChar == ')') {
                         groupState--;
                     }
-                    else if (groupChar == ',') {
+                    else if (groupChar == ',' && groupState == 1) {
                         subValues.add(parseSymbols(compileSymbols(buffer.toString().toCharArray())));
                         buffer.setLength(0);
 


### PR DESCRIPTION
Nested symbols should not be parsed before reaching the end of a group.