### PR TITLE
Using CompletableFuture for asynchronous texture loading to avoid blocking the main thread.

### DIFF
--- a/Fabric/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
@@ -2,7 +2,6 @@ package software.bernie.geckolib.cache.texture;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.concurrent.CompletableFuture;
 

--- a/Fabric/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
@@ -84,7 +84,7 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 	protected RenderCall loadTexture(ResourceManager resourceManager, Minecraft mc) throws IOException {
 		CompletableFuture<AbstractTexture> futureTexture = mc.submit(() -> mc.getTextureManager().getTexture(this.textureBase));
 		
-		return futureTexture.<RenderCall>thenApplyAsync(originalTexture -> {
+		futureTexture.thenAcceptAsync(originalTexture -> {
 			try {
 				Resource textureBaseResource = resourceManager.getResource(this.textureBase).get();
 				NativeImage baseImage = originalTexture instanceof DynamicTexture dynamicTexture ?
@@ -135,9 +135,10 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 				}
 			} catch (IOException e) {
 				GeckoLib.LOGGER.error("Failed to load texture: {}", this.textureBase, e);
-				}
-			return () -> {}; // Return a valid RenderCall instance
-		}, mc).join();
+			}
+		}, mc);
+	
+		return () -> {}; // Return a valid RenderCall instance
 	}
 
 	/**

--- a/Fabric/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
@@ -84,7 +84,7 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 	protected RenderCall loadTexture(ResourceManager resourceManager, Minecraft mc) throws IOException {
 		CompletableFuture<AbstractTexture> futureTexture = mc.submit(() -> mc.getTextureManager().getTexture(this.textureBase));
 		
-		futureTexture.thenAcceptAsync(originalTexture -> {
+		return futureTexture.<RenderCall>thenApplyAsync(originalTexture -> {
 			try {
 				Resource textureBaseResource = resourceManager.getResource(this.textureBase).get();
 				NativeImage baseImage = originalTexture instanceof DynamicTexture dynamicTexture ?
@@ -135,13 +135,9 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 				}
 			} catch (IOException e) {
 				GeckoLib.LOGGER.error("Failed to load texture: {}", this.textureBase, e);
-			}
-		}, mc).exceptionally(e -> {
-			GeckoLib.LOGGER.error("Failed to load texture: {}", this.textureBase, e);
-			return null;
-		});
-	
-		return null;
+				}
+			return () -> {}; // Return a valid RenderCall instance
+		}, mc).join();
 	}
 
 	/**

--- a/Fabric/src/main/java/software/bernie/geckolib/cache/texture/GeoAbstractTexture.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/cache/texture/GeoAbstractTexture.java
@@ -15,6 +15,7 @@ import net.minecraft.server.packs.resources.ResourceManager;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /**
@@ -37,17 +38,25 @@ public abstract class GeoAbstractTexture extends AbstractTexture {
 
 	@Override
 	public final void load(ResourceManager resourceManager) throws IOException {
-		RenderCall renderCall = loadTexture(resourceManager, Minecraft.getInstance());
+		CompletableFuture<RenderCall> futureRenderCall = CompletableFuture.supplyAsync(() -> {
+			try {
+				return loadTexture(resourceManager, Minecraft.getInstance());
+			} catch (IOException e) {
+				e.printStackTrace();
+				return null;
+			}
+		}, Minecraft.getInstance());
 
-		if (renderCall == null)
-			return;
+		futureRenderCall.thenAccept(renderCall -> {
+			if (renderCall == null)
+				return;
 
-		if (!RenderSystem.isOnRenderThreadOrInit()) {
-			RenderSystem.recordRenderCall(renderCall);
-		}
-		else {
-			renderCall.execute();
-		}
+			if (!RenderSystem.isOnRenderThreadOrInit()) {
+				RenderSystem.recordRenderCall(renderCall);
+			} else {
+				renderCall.execute();
+			}
+		});
 	}
 
 	/**

--- a/Forge/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
+++ b/Forge/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
@@ -82,7 +82,7 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 	protected RenderCall loadTexture(ResourceManager resourceManager, Minecraft mc) throws IOException {
 		CompletableFuture<AbstractTexture> futureTexture = mc.submit(() -> mc.getTextureManager().getTexture(this.textureBase));
 		
-		futureTexture.thenAcceptAsync(originalTexture -> {
+		return futureTexture.<RenderCall>thenApplyAsync(originalTexture -> {
 			try {
 				Resource textureBaseResource = resourceManager.getResource(this.textureBase).get();
 				NativeImage baseImage = originalTexture instanceof DynamicTexture dynamicTexture ?
@@ -134,12 +134,8 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 			} catch (IOException e) {
 				GeckoLib.LOGGER.error("Failed to load texture: {}", this.textureBase, e);
 			}
-		}, mc).exceptionally(e -> {
-			GeckoLib.LOGGER.error("Failed to load texture: {}", this.textureBase, e);
-			return null;
-		});
-	
-		return null;
+		return () -> {}; // Return a valid RenderCall instance
+		}, mc).join();
 	}
 
 	/**

--- a/Forge/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
+++ b/Forge/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
@@ -82,7 +82,7 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 	protected RenderCall loadTexture(ResourceManager resourceManager, Minecraft mc) throws IOException {
 		CompletableFuture<AbstractTexture> futureTexture = mc.submit(() -> mc.getTextureManager().getTexture(this.textureBase));
 		
-		return futureTexture.<RenderCall>thenApplyAsync(originalTexture -> {
+		futureTexture.thenAcceptAsync(originalTexture -> {
 			try {
 				Resource textureBaseResource = resourceManager.getResource(this.textureBase).get();
 				NativeImage baseImage = originalTexture instanceof DynamicTexture dynamicTexture ?
@@ -134,8 +134,8 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 			} catch (IOException e) {
 				GeckoLib.LOGGER.error("Failed to load texture: {}", this.textureBase, e);
 			}
+		}, mc);
 		return () -> {}; // Return a valid RenderCall instance
-		}, mc).join();
 	}
 
 	/**

--- a/Forge/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
+++ b/Forge/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
@@ -24,8 +24,8 @@ import software.bernie.geckolib.resource.GeoGlowingTextureMeta;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Texture object type responsible for GeckoLib's emissive render textures
@@ -80,68 +80,66 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 	@Nullable
 	@Override
 	protected RenderCall loadTexture(ResourceManager resourceManager, Minecraft mc) throws IOException {
-		AbstractTexture originalTexture;
-
-		try {
-			originalTexture = mc.submit(() -> mc.getTextureManager().getTexture(this.textureBase)).get();
-		}
-		catch (InterruptedException | ExecutionException e) {
-			throw new IOException("Failed to load original texture: " + this.textureBase, e);
-		}
-
-		Resource textureBaseResource = resourceManager.getResource(this.textureBase).get();
-		NativeImage baseImage = originalTexture instanceof DynamicTexture dynamicTexture ?
-				dynamicTexture.getPixels() : NativeImage.read(textureBaseResource.open());
-		NativeImage glowImage = null;
-		Optional<TextureMetadataSection> textureBaseMeta = textureBaseResource.metadata().getSection(TextureMetadataSection.SERIALIZER);
-		boolean blur = textureBaseMeta.isPresent() && textureBaseMeta.get().isBlur();
-		boolean clamp = textureBaseMeta.isPresent() && textureBaseMeta.get().isClamp();
-
-		try {
-			Optional<Resource> glowLayerResource = resourceManager.getResource(this.glowLayer);
-			GeoGlowingTextureMeta glowLayerMeta = null;
-
-			if (glowLayerResource.isPresent()) {
-				glowImage = NativeImage.read(glowLayerResource.get().open());
-				glowLayerMeta = GeoGlowingTextureMeta.fromExistingImage(glowImage);
-			}
-			else {
-				Optional<GeoGlowingTextureMeta> meta = textureBaseResource.metadata().getSection(GeoGlowingTextureMeta.DESERIALIZER);
-
-				if (meta.isPresent()) {
-					glowLayerMeta = meta.get();
-					glowImage = new NativeImage(baseImage.getWidth(), baseImage.getHeight(), true);
+		CompletableFuture<AbstractTexture> futureTexture = mc.submit(() -> mc.getTextureManager().getTexture(this.textureBase));
+		
+		futureTexture.thenAcceptAsync(originalTexture -> {
+			try {
+				Resource textureBaseResource = resourceManager.getResource(this.textureBase).get();
+				NativeImage baseImage = originalTexture instanceof DynamicTexture dynamicTexture ?
+						dynamicTexture.getPixels() : NativeImage.read(textureBaseResource.open());
+				NativeImage glowImage = null;
+				Optional<TextureMetadataSection> textureBaseMeta = textureBaseResource.metadata().getSection(TextureMetadataSection.SERIALIZER);
+				boolean blur = textureBaseMeta.isPresent() && textureBaseMeta.get().isBlur();
+				boolean clamp = textureBaseMeta.isPresent() && textureBaseMeta.get().isClamp();
+	
+				try {
+					Optional<Resource> glowLayerResource = resourceManager.getResource(this.glowLayer);
+					GeoGlowingTextureMeta glowLayerMeta = null;
+	
+					if (glowLayerResource.isPresent()) {
+						glowImage = NativeImage.read(glowLayerResource.get().open());
+						glowLayerMeta = GeoGlowingTextureMeta.fromExistingImage(glowImage);
+					} else {
+						Optional<GeoGlowingTextureMeta> meta = textureBaseResource.metadata().getSection(GeoGlowingTextureMeta.DESERIALIZER);
+	
+						if (meta.isPresent()) {
+							glowLayerMeta = meta.get();
+							glowImage = new NativeImage(baseImage.getWidth(), baseImage.getHeight(), true);
+						}
+					}
+	
+					if (glowLayerMeta != null) {
+						glowLayerMeta.createImageMask(baseImage, glowImage);
+	
+						if (!FMLEnvironment.production) {
+							printDebugImageToDisk(this.textureBase, baseImage);
+							printDebugImageToDisk(this.glowLayer, glowImage);
+						}
+					}
+				} catch (IOException e) {
+					GeckoLib.LOGGER.warn("Resource failed to open for glowlayer meta: {}", this.glowLayer, e);
 				}
-			}
-
-			if (glowLayerMeta != null) {
-				glowLayerMeta.createImageMask(baseImage, glowImage);
-
-				if (!FMLEnvironment.production) {
-					printDebugImageToDisk(this.textureBase, baseImage);
-					printDebugImageToDisk(this.glowLayer, glowImage);
+	
+				NativeImage mask = glowImage;
+	
+				if (mask != null) {
+					uploadSimple(getId(), mask, blur, clamp);
+	
+					if (originalTexture instanceof DynamicTexture dynamicTexture) {
+						dynamicTexture.upload();
+					} else {
+						uploadSimple(originalTexture.getId(), baseImage, blur, clamp);
+					}
 				}
+			} catch (IOException e) {
+				GeckoLib.LOGGER.error("Failed to load texture: {}", this.textureBase, e);
 			}
-		}
-		catch (IOException e) {
-			GeckoLib.LOGGER.warn("Resource failed to open for glowlayer meta: {}", this.glowLayer, e);
-		}
-
-		NativeImage mask = glowImage;
-
-		if (mask == null)
+		}, mc).exceptionally(e -> {
+			GeckoLib.LOGGER.error("Failed to load texture: {}", this.textureBase, e);
 			return null;
-
-		return () -> {
-			uploadSimple(getId(), mask, blur, clamp);
-
-			if (originalTexture instanceof DynamicTexture dynamicTexture) {
-				dynamicTexture.upload();
-			}
-			else {
-				uploadSimple(originalTexture.getId(), baseImage, blur, clamp);
-			}
-		};
+		});
+	
+		return null;
 	}
 
 	/**

--- a/NeoForge/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
@@ -82,7 +82,7 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 	protected RenderCall loadTexture(ResourceManager resourceManager, Minecraft mc) throws IOException {
 		CompletableFuture<AbstractTexture> futureTexture = mc.submit(() -> mc.getTextureManager().getTexture(this.textureBase));
 		
-		futureTexture.thenAcceptAsync(originalTexture -> {
+		return futureTexture.<RenderCall>thenApplyAsync(originalTexture -> {
 			try {
 				Resource textureBaseResource = resourceManager.getResource(this.textureBase).get();
 				NativeImage baseImage = originalTexture instanceof DynamicTexture dynamicTexture ?
@@ -134,12 +134,8 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 			} catch (IOException e) {
 				GeckoLib.LOGGER.error("Failed to load texture: {}", this.textureBase, e);
 			}
-		}, mc).exceptionally(e -> {
-			GeckoLib.LOGGER.error("Failed to load texture: {}", this.textureBase, e);
-			return null;
-		});
-	
-		return null;
+		return () -> {}; // Return a valid RenderCall instance
+		}, mc).join();
 	}
 
 	/**

--- a/NeoForge/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
@@ -82,7 +82,7 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 	protected RenderCall loadTexture(ResourceManager resourceManager, Minecraft mc) throws IOException {
 		CompletableFuture<AbstractTexture> futureTexture = mc.submit(() -> mc.getTextureManager().getTexture(this.textureBase));
 		
-		return futureTexture.<RenderCall>thenApplyAsync(originalTexture -> {
+		futureTexture.thenAcceptAsync(originalTexture -> {
 			try {
 				Resource textureBaseResource = resourceManager.getResource(this.textureBase).get();
 				NativeImage baseImage = originalTexture instanceof DynamicTexture dynamicTexture ?
@@ -134,8 +134,8 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 			} catch (IOException e) {
 				GeckoLib.LOGGER.error("Failed to load texture: {}", this.textureBase, e);
 			}
+		}, mc);
 		return () -> {}; // Return a valid RenderCall instance
-		}, mc).join();
 	}
 
 	/**

--- a/NeoForge/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
@@ -24,8 +24,8 @@ import software.bernie.geckolib.resource.GeoGlowingTextureMeta;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Texture object type responsible for GeckoLib's emissive render textures
@@ -80,68 +80,66 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 	@Nullable
 	@Override
 	protected RenderCall loadTexture(ResourceManager resourceManager, Minecraft mc) throws IOException {
-		AbstractTexture originalTexture;
-
-		try {
-			originalTexture = mc.submit(() -> mc.getTextureManager().getTexture(this.textureBase)).get();
-		}
-		catch (InterruptedException | ExecutionException e) {
-			throw new IOException("Failed to load original texture: " + this.textureBase, e);
-		}
-
-		Resource textureBaseResource = resourceManager.getResource(this.textureBase).get();
-		NativeImage baseImage = originalTexture instanceof DynamicTexture dynamicTexture ?
-				dynamicTexture.getPixels() : NativeImage.read(textureBaseResource.open());
-		NativeImage glowImage = null;
-		Optional<TextureMetadataSection> textureBaseMeta = textureBaseResource.metadata().getSection(TextureMetadataSection.SERIALIZER);
-		boolean blur = textureBaseMeta.isPresent() && textureBaseMeta.get().isBlur();
-		boolean clamp = textureBaseMeta.isPresent() && textureBaseMeta.get().isClamp();
-
-		try {
-			Optional<Resource> glowLayerResource = resourceManager.getResource(this.glowLayer);
-			GeoGlowingTextureMeta glowLayerMeta = null;
-
-			if (glowLayerResource.isPresent()) {
-				glowImage = NativeImage.read(glowLayerResource.get().open());
-				glowLayerMeta = GeoGlowingTextureMeta.fromExistingImage(glowImage);
-			}
-			else {
-				Optional<GeoGlowingTextureMeta> meta = textureBaseResource.metadata().getSection(GeoGlowingTextureMeta.DESERIALIZER);
-
-				if (meta.isPresent()) {
-					glowLayerMeta = meta.get();
-					glowImage = new NativeImage(baseImage.getWidth(), baseImage.getHeight(), true);
+		CompletableFuture<AbstractTexture> futureTexture = mc.submit(() -> mc.getTextureManager().getTexture(this.textureBase));
+		
+		futureTexture.thenAcceptAsync(originalTexture -> {
+			try {
+				Resource textureBaseResource = resourceManager.getResource(this.textureBase).get();
+				NativeImage baseImage = originalTexture instanceof DynamicTexture dynamicTexture ?
+						dynamicTexture.getPixels() : NativeImage.read(textureBaseResource.open());
+				NativeImage glowImage = null;
+				Optional<TextureMetadataSection> textureBaseMeta = textureBaseResource.metadata().getSection(TextureMetadataSection.SERIALIZER);
+				boolean blur = textureBaseMeta.isPresent() && textureBaseMeta.get().isBlur();
+				boolean clamp = textureBaseMeta.isPresent() && textureBaseMeta.get().isClamp();
+	
+				try {
+					Optional<Resource> glowLayerResource = resourceManager.getResource(this.glowLayer);
+					GeoGlowingTextureMeta glowLayerMeta = null;
+	
+					if (glowLayerResource.isPresent()) {
+						glowImage = NativeImage.read(glowLayerResource.get().open());
+						glowLayerMeta = GeoGlowingTextureMeta.fromExistingImage(glowImage);
+					} else {
+						Optional<GeoGlowingTextureMeta> meta = textureBaseResource.metadata().getSection(GeoGlowingTextureMeta.DESERIALIZER);
+	
+						if (meta.isPresent()) {
+							glowLayerMeta = meta.get();
+							glowImage = new NativeImage(baseImage.getWidth(), baseImage.getHeight(), true);
+						}
+					}
+	
+					if (glowLayerMeta != null) {
+						glowLayerMeta.createImageMask(baseImage, glowImage);
+	
+						if (!FMLEnvironment.production) {
+							printDebugImageToDisk(this.textureBase, baseImage);
+							printDebugImageToDisk(this.glowLayer, glowImage);
+						}
+					}
+				} catch (IOException e) {
+					GeckoLib.LOGGER.warn("Resource failed to open for glowlayer meta: {}", this.glowLayer, e);
 				}
-			}
-
-			if (glowLayerMeta != null) {
-				glowLayerMeta.createImageMask(baseImage, glowImage);
-
-				if (!FMLEnvironment.production) {
-					printDebugImageToDisk(this.textureBase, baseImage);
-					printDebugImageToDisk(this.glowLayer, glowImage);
+	
+				NativeImage mask = glowImage;
+	
+				if (mask != null) {
+					uploadSimple(getId(), mask, blur, clamp);
+	
+					if (originalTexture instanceof DynamicTexture dynamicTexture) {
+						dynamicTexture.upload();
+					} else {
+						uploadSimple(originalTexture.getId(), baseImage, blur, clamp);
+					}
 				}
+			} catch (IOException e) {
+				GeckoLib.LOGGER.error("Failed to load texture: {}", this.textureBase, e);
 			}
-		}
-		catch (IOException e) {
-			GeckoLib.LOGGER.warn("Resource failed to open for glowlayer meta: {}", this.glowLayer, e);
-		}
-
-		NativeImage mask = glowImage;
-
-		if (mask == null)
+		}, mc).exceptionally(e -> {
+			GeckoLib.LOGGER.error("Failed to load texture: {}", this.textureBase, e);
 			return null;
-
-		return () -> {
-			uploadSimple(getId(), mask, blur, clamp);
-
-			if (originalTexture instanceof DynamicTexture dynamicTexture) {
-				dynamicTexture.upload();
-			}
-			else {
-				uploadSimple(originalTexture.getId(), baseImage, blur, clamp);
-			}
-		};
+		});
+	
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
The original code does not typically cause issues. However, when using the [Hybrid Aquatic](https://modrinth.com/mod/hybrid-aquatic) and [Physics Mod Pro](https://minecraftphysicsmod.com/pro) mods simultaneously, there is a chance that the game may become unresponsive. This unresponsiveness may occur when both [Physics Mod Pro](https://minecraftphysicsmod.com/pro) and [Physics Mod](https://minecraftphysicsmod.com/) are used together. Upon investigation, it appears that the `loadTexture` method in `AutoGlowingTexture.java` of the [geckolib](https://github.com/bernie-g/geckolib) library blocks the main thread. Employing asynchronous loading with CompletableFuture effectively addresses this issue.
