### PR TITLE
Don't update animations if entities arent ticking

### DIFF
--- a/common/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/common/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -205,7 +205,7 @@ public abstract class GeoModel<T extends GeoAnimatable> {
 		processor.preAnimationSetup(animationState, this.animTime);
 
 		if (!processor.getRegisteredBones().isEmpty())
-			processor.tickAnimation(animatable, this, animatableManager, this.animTime, animationState, crashIfBoneMissing());
+			processor.tickAnimation(animatable, this, animatableManager, currentTick > 0 ? this.animTime : 0, animationState, crashIfBoneMissing());
 
 		setCustomAnimations(animatable, instanceId, animationState);
 	}


### PR DESCRIPTION
Hello!

For years now, this library has been causing me many problems with my trophy mod, [OpenBlocks Trophies](https://www.curseforge.com/minecraft/mc-mods/openblocks-trophies). Displaying mobs that use this library to play animations would cause them to play animations (which I was trying to avoid, I don't see this happen anymore nowadays luckily), jitter (which looks really bad), or rarely not play animations at all (which is what I wanted). This inconsistency drove me nuts and caused me to not support mods that use the mod. However, with so many mods using it, I needed to find a way around it. 

Years later and I finally found some free time and tracked down my problem. This PR will simply not try to play animations if the entity isn't ticking. When a fake entity is rendered, its `tickCount` is never incremented, meaning `currentTick` will always be 0. `animTime` interpolates between the last tick and the current one, so the last and current time will always be 0. This is what causes the jittering, so the idea is to just not use `animTime` if the entity is not ticking. This works like a charm and doesn't affect real entity animations in any way. 

I would be happy to PR this on older versions too (probably just as far back to 1.20.1) as I desperately need this fix so I can add more mod support to my trophy mod. I dont know if you guys accept backports though so I wont open anything else until this is approved and I know a backport will be uploaded. Thanks for taking the time to look at this and have a lovely day :)