### PR TITLE
Use the correct partialTick when ticking animations

### DIFF
--- a/Fabric/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -184,7 +184,7 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 	 */
 	@ApiStatus.Internal
 	@Override
-	public void handleAnimations(T animatable, long instanceId, AnimationState<T> animationState) {
+	public void handleAnimations(T animatable, long instanceId, AnimationState<T> animationState, float partialTick) {
 		Minecraft mc = Minecraft.getInstance();
 		AnimatableManager<T> animatableManager = animatable.getAnimatableInstanceCache().getManagerForId(instanceId);
 		Double currentTick = animationState.getData(DataTickets.TICK);
@@ -193,9 +193,9 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 			currentTick = animatable instanceof Entity entity ? (double)entity.tickCount : RenderUtils.getCurrentTick();
 
 		if (animatableManager.getFirstTickTime() == -1)
-			animatableManager.startedAt(currentTick + mc.getFrameTime());
+			animatableManager.startedAt(currentTick + partialTick);
 
-		double currentFrameTime = animatable instanceof Entity ? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
+		double currentFrameTime = animatable instanceof Entity ? currentTick + partialTick : currentTick - animatableManager.getFirstTickTime();
 		boolean isReRender = !animatableManager.isFirstTick() && currentFrameTime == animatableManager.getLastUpdateTime();
 
 		if (isReRender && instanceId == this.lastRenderedInstance)

--- a/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoArmorRenderer.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoArmorRenderer.java
@@ -298,7 +298,7 @@ public class GeoArmorRenderer<T extends Item & GeoItem> extends HumanoidModel im
 			animationState.setData(DataTickets.ENTITY, this.currentEntity);
 			animationState.setData(DataTickets.EQUIPMENT_SLOT, this.currentSlot);
 			this.model.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			this.model.handleAnimations(animatable, instanceId, animationState);
+			this.model.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		this.modelRenderTranslations = new Matrix4f(poseStack.last().pose());

--- a/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoBlockRenderer.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoBlockRenderer.java
@@ -146,7 +146,7 @@ public class GeoBlockRenderer<T extends BlockEntity & GeoAnimatable> implements 
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
 			poseStack.translate(0.5, 0, 0.5);
 			rotateBlock(getFacing(animatable), poseStack);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		this.modelRenderTranslations = new Matrix4f(poseStack.last().pose());

--- a/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoEntityRenderer.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoEntityRenderer.java
@@ -216,7 +216,7 @@ public class GeoEntityRenderer<T extends Entity & GeoAnimatable> extends EntityR
 			animationState.setData(DataTickets.ENTITY, animatable);
 			animationState.setData(DataTickets.ENTITY_MODEL_DATA, new EntityModelData(shouldSit, livingEntity != null && livingEntity.isBaby(), -netHeadYaw, -headPitch));
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		poseStack.translate(0, 0.01f, 0);

--- a/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoItemRenderer.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoItemRenderer.java
@@ -223,7 +223,7 @@ public class GeoItemRenderer<T extends Item & GeoAnimatable> extends BlockEntity
 			animationState.setData(DataTickets.ITEMSTACK, this.currentItemStack);
 			animatable.getAnimatableInstanceCache().getManagerForId(instanceId).setData(DataTickets.ITEM_RENDER_PERSPECTIVE, this.renderPerspective);
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		this.modelRenderTranslations = new Matrix4f(poseStack.last().pose());

--- a/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoObjectRenderer.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoObjectRenderer.java
@@ -154,7 +154,7 @@ public class GeoObjectRenderer<T extends GeoAnimatable> implements GeoRenderer<T
 			GeoModel<T> currentModel = getGeoModel();
 
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		this.modelRenderTranslations = new Matrix4f(poseStack.last().pose());

--- a/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoReplacedEntityRenderer.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/renderer/GeoReplacedEntityRenderer.java
@@ -243,7 +243,7 @@ public class GeoReplacedEntityRenderer<E extends Entity, T extends GeoAnimatable
 			animationState.setData(DataTickets.ENTITY, this.currentEntity);
 			animationState.setData(DataTickets.ENTITY_MODEL_DATA, new EntityModelData(shouldSit, livingEntity != null && livingEntity.isBaby(), -netHeadYaw, -headPitch));
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		poseStack.translate(0, 0.01f, 0);

--- a/Forge/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/Forge/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -184,7 +184,7 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 	 */
 	@ApiStatus.Internal
 	@Override
-	public void handleAnimations(T animatable, long instanceId, AnimationState<T> animationState) {
+	public void handleAnimations(T animatable, long instanceId, AnimationState<T> animationState, float partialTick) {
 		Minecraft mc = Minecraft.getInstance();
 		AnimatableManager<T> animatableManager = animatable.getAnimatableInstanceCache().getManagerForId(instanceId);
 		Double currentTick = animationState.getData(DataTickets.TICK);
@@ -193,9 +193,9 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 			currentTick = animatable instanceof Entity entity ? (double)entity.tickCount : RenderUtils.getCurrentTick();
 
 		if (animatableManager.getFirstTickTime() == -1)
-			animatableManager.startedAt(currentTick + mc.getFrameTime());
+			animatableManager.startedAt(currentTick + partialTick);
 
-		double currentFrameTime = animatable instanceof Entity ? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
+		double currentFrameTime = animatable instanceof Entity ? currentTick + partialTick : currentTick - animatableManager.getFirstTickTime();
 		boolean isReRender = !animatableManager.isFirstTick() && currentFrameTime == animatableManager.getLastUpdateTime();
 
 		if (isReRender && instanceId == this.lastRenderedInstance)

--- a/Forge/src/main/java/software/bernie/geckolib/renderer/GeoArmorRenderer.java
+++ b/Forge/src/main/java/software/bernie/geckolib/renderer/GeoArmorRenderer.java
@@ -299,7 +299,7 @@ public class GeoArmorRenderer<T extends Item & GeoItem> extends HumanoidModel im
 			animationState.setData(DataTickets.ENTITY, this.currentEntity);
 			animationState.setData(DataTickets.EQUIPMENT_SLOT, this.currentSlot);
 			this.model.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			this.model.handleAnimations(animatable, instanceId, animationState);
+			this.model.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		this.modelRenderTranslations = new Matrix4f(poseStack.last().pose());

--- a/Forge/src/main/java/software/bernie/geckolib/renderer/GeoBlockRenderer.java
+++ b/Forge/src/main/java/software/bernie/geckolib/renderer/GeoBlockRenderer.java
@@ -147,7 +147,7 @@ public class GeoBlockRenderer<T extends BlockEntity & GeoAnimatable> implements 
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
 			poseStack.translate(0.5, 0, 0.5);
 			rotateBlock(getFacing(animatable), poseStack);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		this.modelRenderTranslations = new Matrix4f(poseStack.last().pose());

--- a/Forge/src/main/java/software/bernie/geckolib/renderer/GeoEntityRenderer.java
+++ b/Forge/src/main/java/software/bernie/geckolib/renderer/GeoEntityRenderer.java
@@ -217,7 +217,7 @@ public class GeoEntityRenderer<T extends Entity & GeoAnimatable> extends EntityR
 			animationState.setData(DataTickets.ENTITY, animatable);
 			animationState.setData(DataTickets.ENTITY_MODEL_DATA, new EntityModelData(shouldSit, livingEntity != null && livingEntity.isBaby(), -netHeadYaw, -headPitch));
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		poseStack.translate(0, 0.01f, 0);

--- a/Forge/src/main/java/software/bernie/geckolib/renderer/GeoItemRenderer.java
+++ b/Forge/src/main/java/software/bernie/geckolib/renderer/GeoItemRenderer.java
@@ -224,7 +224,7 @@ public class GeoItemRenderer<T extends Item & GeoAnimatable> extends BlockEntity
 			animationState.setData(DataTickets.ITEMSTACK, this.currentItemStack);
 			animatable.getAnimatableInstanceCache().getManagerForId(instanceId).setData(DataTickets.ITEM_RENDER_PERSPECTIVE, this.renderPerspective);
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		this.modelRenderTranslations = new Matrix4f(poseStack.last().pose());

--- a/Forge/src/main/java/software/bernie/geckolib/renderer/GeoObjectRenderer.java
+++ b/Forge/src/main/java/software/bernie/geckolib/renderer/GeoObjectRenderer.java
@@ -155,7 +155,7 @@ public class GeoObjectRenderer<T extends GeoAnimatable> implements GeoRenderer<T
 			GeoModel<T> currentModel = getGeoModel();
 
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		this.modelRenderTranslations = new Matrix4f(poseStack.last().pose());

--- a/Forge/src/main/java/software/bernie/geckolib/renderer/GeoReplacedEntityRenderer.java
+++ b/Forge/src/main/java/software/bernie/geckolib/renderer/GeoReplacedEntityRenderer.java
@@ -237,7 +237,7 @@ public class GeoReplacedEntityRenderer<E extends Entity, T extends GeoAnimatable
 			animationState.setData(DataTickets.ENTITY, this.currentEntity);
 			animationState.setData(DataTickets.ENTITY_MODEL_DATA, new EntityModelData(shouldSit, livingEntity != null && livingEntity.isBaby(), -netHeadYaw, -headPitch));
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		poseStack.translate(0, 0.01f, 0);

--- a/NeoForge/src/main/java/software/bernie/geckolib/model/GeoModel.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/model/GeoModel.java
@@ -183,7 +183,7 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 	 */
 	@ApiStatus.Internal
 	@Override
-	public void handleAnimations(T animatable, long instanceId, AnimationState<T> animationState) {
+	public void handleAnimations(T animatable, long instanceId, AnimationState<T> animationState, float partialTick) {
 		Minecraft mc = Minecraft.getInstance();
 		AnimatableManager<T> animatableManager = animatable.getAnimatableInstanceCache().getManagerForId(instanceId);
 		Double currentTick = animationState.getData(DataTickets.TICK);
@@ -192,9 +192,9 @@ public abstract class GeoModel<T extends GeoAnimatable> implements CoreGeoModel<
 			currentTick = animatable instanceof Entity entity ? (double)entity.tickCount : RenderUtils.getCurrentTick();
 
 		if (animatableManager.getFirstTickTime() == -1)
-			animatableManager.startedAt(currentTick + mc.getFrameTime());
+			animatableManager.startedAt(currentTick + partialTick);
 
-		double currentFrameTime = animatable instanceof Entity ? currentTick + mc.getFrameTime() : currentTick - animatableManager.getFirstTickTime();
+		double currentFrameTime = animatable instanceof Entity ? currentTick + partialTick : currentTick - animatableManager.getFirstTickTime();
 		boolean isReRender = !animatableManager.isFirstTick() && currentFrameTime == animatableManager.getLastUpdateTime();
 
 		if (isReRender && instanceId == this.lastRenderedInstance)

--- a/NeoForge/src/main/java/software/bernie/geckolib/renderer/GeoArmorRenderer.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/renderer/GeoArmorRenderer.java
@@ -299,7 +299,7 @@ public class GeoArmorRenderer<T extends Item & GeoItem> extends HumanoidModel im
 			animationState.setData(DataTickets.ENTITY, this.currentEntity);
 			animationState.setData(DataTickets.EQUIPMENT_SLOT, this.currentSlot);
 			this.model.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			this.model.handleAnimations(animatable, instanceId, animationState);
+			this.model.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		this.modelRenderTranslations = new Matrix4f(poseStack.last().pose());

--- a/NeoForge/src/main/java/software/bernie/geckolib/renderer/GeoBlockRenderer.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/renderer/GeoBlockRenderer.java
@@ -146,7 +146,7 @@ public class GeoBlockRenderer<T extends BlockEntity & GeoAnimatable> implements 
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
 			poseStack.translate(0.5, 0, 0.5);
 			rotateBlock(getFacing(animatable), poseStack);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		this.modelRenderTranslations = new Matrix4f(poseStack.last().pose());

--- a/NeoForge/src/main/java/software/bernie/geckolib/renderer/GeoEntityRenderer.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/renderer/GeoEntityRenderer.java
@@ -217,7 +217,7 @@ public class GeoEntityRenderer<T extends Entity & GeoAnimatable> extends EntityR
 			animationState.setData(DataTickets.ENTITY, animatable);
 			animationState.setData(DataTickets.ENTITY_MODEL_DATA, new EntityModelData(shouldSit, livingEntity != null && livingEntity.isBaby(), -netHeadYaw, -headPitch));
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		poseStack.translate(0, 0.01f, 0);

--- a/NeoForge/src/main/java/software/bernie/geckolib/renderer/GeoItemRenderer.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/renderer/GeoItemRenderer.java
@@ -225,7 +225,7 @@ public class GeoItemRenderer<T extends Item & GeoAnimatable> extends BlockEntity
 			animationState.setData(DataTickets.ITEMSTACK, this.currentItemStack);
 			animatable.getAnimatableInstanceCache().getManagerForId(instanceId).setData(DataTickets.ITEM_RENDER_PERSPECTIVE, this.renderPerspective);
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		this.modelRenderTranslations = new Matrix4f(poseStack.last().pose());

--- a/NeoForge/src/main/java/software/bernie/geckolib/renderer/GeoObjectRenderer.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/renderer/GeoObjectRenderer.java
@@ -155,7 +155,7 @@ public class GeoObjectRenderer<T extends GeoAnimatable> implements GeoRenderer<T
 			GeoModel<T> currentModel = getGeoModel();
 
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		this.modelRenderTranslations = new Matrix4f(poseStack.last().pose());

--- a/NeoForge/src/main/java/software/bernie/geckolib/renderer/GeoReplacedEntityRenderer.java
+++ b/NeoForge/src/main/java/software/bernie/geckolib/renderer/GeoReplacedEntityRenderer.java
@@ -237,7 +237,7 @@ public class GeoReplacedEntityRenderer<E extends Entity, T extends GeoAnimatable
 			animationState.setData(DataTickets.ENTITY, this.currentEntity);
 			animationState.setData(DataTickets.ENTITY_MODEL_DATA, new EntityModelData(shouldSit, livingEntity != null && livingEntity.isBaby(), -netHeadYaw, -headPitch));
 			currentModel.addAdditionalStateData(animatable, instanceId, animationState::setData);
-			currentModel.handleAnimations(animatable, instanceId, animationState);
+			currentModel.handleAnimations(animatable, instanceId, animationState, partialTick);
 		}
 
 		poseStack.translate(0, 0.01f, 0);

--- a/core/src/main/java/software/bernie/geckolib/core/animatable/model/CoreGeoModel.java
+++ b/core/src/main/java/software/bernie/geckolib/core/animatable/model/CoreGeoModel.java
@@ -46,7 +46,7 @@ public interface CoreGeoModel<E extends GeoAnimatable> {
 	 * This method is called once per render frame for each {@link GeoAnimatable} being rendered.<br>
 	 * It is an internal method for automated animation parsing. Use {@link CoreGeoModel#setCustomAnimations(GeoAnimatable, long, AnimationState)} for custom animation work
 	 */
-	void handleAnimations(E animatable, long instanceId, AnimationState<E> animationState);
+	void handleAnimations(E animatable, long instanceId, AnimationState<E> animationState, float partialTick);
 
 	/**
 	 * This method is called once per render frame for each {@link GeoAnimatable} being rendered.<br>


### PR DESCRIPTION
A continuation of #671 after I realized there was a better approach after surfing through the code again. This version of the PR passes the proper `partialTick` to `handleAnimations` as I found out the proper one is used everywhere EXCEPT the place that needs it most. 

I only messed with this method as it was marked as internal so people shouldn't be messing with it anyway. I do however, recognize `setCustomAnimations` would also need `partialTick` passed in and I didn't want to do that since that one is an actual API method. I will either leave that for you guys to do or I can do it if the go ahead is given. 

~~If this PR is accepted I will also open one for 1.21 if that's cool~~ (EDIT: after looking over 1.21 it already does this. No need for another PR). 1.21 and 1.21.4 will also need `partialTick` passed into `setCustomAnimations` if thats done here too. Thanks for looking over this :)