### PR TITLE
Fixed incompatibility with player animator

### DIFF
--- a/common/src/main/java/software/bernie/geckolib/renderer/GeoArmorRenderer.java
+++ b/common/src/main/java/software/bernie/geckolib/renderer/GeoArmorRenderer.java
@@ -294,8 +294,9 @@ public class GeoArmorRenderer<T extends Item & GeoItem> extends HumanoidModel im
 		scaleModelForBaby(poseStack, animatable, partialTick, isReRender);
 		scaleModelForRender(this.scaleWidth, this.scaleHeight, poseStack, animatable, model, isReRender, partialTick, packedLight, packedOverlay);
 
-		if (!(this.currentEntity instanceof GeoAnimatable))
-			applyBoneVisibilityBySlot(this.currentSlot);
+		if (!(this.currentEntity instanceof GeoAnimatable)) {
+			applyBoneVisibilityFromBaseModel(this.baseModel);
+		}
 	}
 
 	@Override
@@ -480,6 +481,15 @@ public class GeoArmorRenderer<T extends Item & GeoItem> extends HumanoidModel im
 			}
 			default -> {}
 		}
+	}
+	
+	protected void applyBoneVisibilityFromBaseModel(HumanoidModel<?> model) {
+		setBoneVisible(this.head, model.head.visible);
+		setBoneVisible(this.body, model.body.visible);
+		setBoneVisible(this.rightArm, model.rightArm.visible);
+		setBoneVisible(this.leftArm, model.leftArm.visible);
+		setBoneVisible(this.rightLeg, model.rightLeg.visible);
+		setBoneVisible(this.leftLeg, model.leftLeg.visible);
 	}
 
 	/**


### PR DESCRIPTION
Player animator recently added a feature where you can render the armor alongside the arms in first person.
This was done using this mixin:
https://github.com/KosmX/minecraftPlayerAnimator/blob/1.21/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/ArmorFeatureRendererMixin.java
But GeckoLib ignores everything the setPartVisibility method does so the entire armor gets rendered while only the arms are supposed to be rendered
This PR will hopefully fix that without breaking anything else in the process

I did try doing it like this:
```
	protected void applyBoneVisibilityFromBaseModel(HumanoidModel<?> model) {
		setBoneVisible(this.model.getBone("bipedHead").orElseGet(() -> this.head), model.head.visible);
		setBoneVisible(this.model.getBone("bipedBody").orElseGet(() -> this.body), model.body.visible);
		setBoneVisible(this.model.getBone("bipedRightArm").orElseGet(() -> this.rightArm), model.rightArm.visible);
		setBoneVisible(this.model.getBone("bipedLeftArm").orElseGet(() -> this.leftArm), model.leftArm.visible);
		setBoneVisible(this.model.getBone("bipedRightLeg").orElseGet(() -> this.rightLeg), model.rightLeg.visible);
		setBoneVisible(this.model.getBone("bipedLeftLeg").orElseGet(() -> this.leftLeg), model.leftLeg.visible);
	}
```
And it does work better but I still didn't include it in the commit in case you don't like it

Let me know if this PR looks good or if we should look for other ways to solve this issue