### PR TITLE
Pass ItemStack to GeoRenderProvider#getGeoItemRenderer

### DIFF
--- a/common/src/main/java/software/bernie/geckolib/animatable/client/GeoRenderProvider.java
+++ b/common/src/main/java/software/bernie/geckolib/animatable/client/GeoRenderProvider.java
@@ -55,7 +55,7 @@ public interface GeoRenderProvider {
      * @return The cached BEWLR instance for this provider, or null if not applicable
      */
     @Nullable
-    default GeoItemRenderer<?> getGeoItemRenderer() {
+    default GeoItemRenderer<?> getGeoItemRenderer(ItemStack stack) {
         return null;
     }
 

--- a/common/src/main/java/software/bernie/geckolib/renderer/base/GeckolibItemSpecialRenderer.java
+++ b/common/src/main/java/software/bernie/geckolib/renderer/base/GeckolibItemSpecialRenderer.java
@@ -44,7 +44,7 @@ public class GeckolibItemSpecialRenderer<T extends Item & GeoAnimatable> impleme
     public GeckolibItemSpecialRenderer.RenderData<T> extractArgument(ItemStack itemStack, ItemStackRenderState renderState, ItemDisplayContext context,
                                                                      @Nullable ClientLevel level, @Nullable LivingEntity entity) {
         var item = makeCovariantItem(itemStack.getItem());
-        GeoItemRenderer<T> renderer = (GeoItemRenderer)GeoRenderProvider.of(item).getGeoItemRenderer();
+        GeoItemRenderer<T> renderer = (GeoItemRenderer)GeoRenderProvider.of(item).getGeoItemRenderer(itemStack);
 
         if (renderer == null)
             return null;

--- a/fabric/src/main/java/software/bernie/geckolib/platform/GeckoLibClientFabric.java
+++ b/fabric/src/main/java/software/bernie/geckolib/platform/GeckoLibClientFabric.java
@@ -38,7 +38,7 @@ public class GeckoLibClientFabric implements GeckoLibClient {
     @Nullable
     @Override
     public GeoModel<?> getGeoModelForItem(ItemStack item) {
-        if (GeoRenderProvider.of(item).getGeoItemRenderer() instanceof GeoRenderer<?, ?, ?> geoItemRenderer)
+        if (GeoRenderProvider.of(item).getGeoItemRenderer(item) instanceof GeoRenderer<?, ?, ?> geoItemRenderer)
             return geoItemRenderer.getGeoModel();
 
         return null;

--- a/forge/src/main/java/software/bernie/geckolib/platform/GeckoLibClientForge.java
+++ b/forge/src/main/java/software/bernie/geckolib/platform/GeckoLibClientForge.java
@@ -49,7 +49,7 @@ public final class GeckoLibClientForge implements GeckoLibClient {
     @Nullable
     @Override
     public GeoModel<?> getGeoModelForItem(ItemStack item) {
-        if (GeoRenderProvider.of(item).getGeoItemRenderer() instanceof GeoRenderer<?, ?, ?> geoRenderer)
+        if (GeoRenderProvider.of(item).getGeoItemRenderer(item) instanceof GeoRenderer<?, ?, ?> geoRenderer)
             return geoRenderer.getGeoModel();
 
         return null;

--- a/neoforge/src/main/java/software/bernie/geckolib/platform/GeckoLibClientNeoForge.java
+++ b/neoforge/src/main/java/software/bernie/geckolib/platform/GeckoLibClientNeoForge.java
@@ -46,7 +46,7 @@ public class GeckoLibClientNeoForge implements GeckoLibClient {
     @Nullable
     @Override
     public GeoModel<?> getGeoModelForItem(ItemStack item) {
-        if (GeoRenderProvider.of(item).getGeoItemRenderer() instanceof GeoRenderer<?, ?, ?> geoRenderer)
+        if (GeoRenderProvider.of(item).getGeoItemRenderer(item) instanceof GeoRenderer<?, ?, ?> geoRenderer)
             return geoRenderer.getGeoModel();
 
         return null;


### PR DESCRIPTION
This would make it possible (or at least significantly easier, because I can't find any way to get the `ItemStack` instance within that context) to swap item renderers based based on conditions for each `ItemStack`.

According to Intelij, all the locations that method is called, also have an `ItemStack`, because it needs it to even find the `GeoRenderProvider`

The only change developers should need to make is to add the `ItemStack` parameter

example usage:
```java
public interface CustomGeoItem<T extends Item & CustomGeoItem<T>> extends GeoItem {

    [...]

    String getID();

    @Override
    default void createGeoRenderer(Consumer<GeoRenderProvider> consumer) {
        consumer.accept(new GeoRenderProvider() {
            private final HolGeoEmissiveItemRenderer<T> emissiveItemRenderer = new HolGeoEmissiveItemRenderer<>(getID());
            private final HolGeoItemRenderer<T> itemRenderer = new HolGeoItemRenderer<>(getID());

            @Override
            public @NotNull GeoItemRenderer<?> getGeoItemRenderer(ItemStack stack) {
                if (stack.getItem() instanceof ChargeableItem chargeableItem) {
                    // chargableItem#isCharged is just a helper method that returns the boolean value of a custom data component
                    return chargeableItem.isCharged(stack) ? emissiveItemRenderer : itemRenderer;
                }
                return itemRenderer;
            }
        });
    }

   [...]

}
```

https://github.com/user-attachments/assets/14f7aaf6-7af8-474d-b86d-c5c28ef9b86a

