### PR TITLE
Fix crash when glow layer and base image sizes don't match

### DIFF
--- a/common/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
+++ b/common/src/main/java/software/bernie/geckolib/cache/texture/AutoGlowingTexture.java
@@ -146,6 +146,16 @@ public class AutoGlowingTexture extends GeoAbstractTexture {
 		if (mask == null)
 			return null;
 
+		//throw an exception if the image dimensions dont add up
+		if (mask.getWidth() != baseImage.getWidth() || mask.getHeight() != baseImage.getHeight()) {
+			//if its a glowImage
+			if (resourceManager.getResource(this.glowLayer).isPresent()) {
+				String formatText = String.format("Glow image for texture %s has diferent dimensions than base image: %s",
+						this.glowLayer, this.textureBase);
+				throw new IOException(formatText);
+			}
+		}
+
 		boolean animated = originalTexture instanceof AnimatableTexture animatableTexture && animatableTexture.isAnimated();
 
 		if (animated)


### PR DESCRIPTION
The exception is now visible in the log, rather than crashing the game with a harder to read message.