### PR TITLE
fix(renderer): isolate cube transforms with PoseStack push/pop

### DIFF
--- a/common/src/main/java/software/bernie/geckolib/renderer/layer/builtin/CustomBoneTextureGeoLayer.java
+++ b/common/src/main/java/software/bernie/geckolib/renderer/layer/builtin/CustomBoneTextureGeoLayer.java
@@ -126,7 +126,9 @@ public class CustomBoneTextureGeoLayer<T extends GeoAnimatable, O, R extends Geo
                 bone.translateAwayFromPivotPoint(poseStack);
 
                 for (GeoCube cube : ((CuboidGeoBone)bone).cubes) {
+                    poseStack.pushPose();
                     renderCube(cube, poseStack, buffer, packedLight, packedOverlay, renderColor, widthRatio, heightRatio);
+                    poseStack.popPose();
                 }
 
                 poseStack.popPose();


### PR DESCRIPTION
## Problem

Cube transformations were leaking into subsequent cubes during rendering.

Because cube transformations modify the PoseStack, rendering multiple cubes
without isolating the matrix state causes later cubes to inherit the
transformations of the previous ones.

#Code
```java
//Custom Layer
public class GunCustomLayerRenderer extends CustomBoneTextureGeoLayer<ItemGun, GeoItemRenderer.RenderData, GeoRenderState> {
    public GunCustomLayerRenderer(GeoRenderer<ItemGun, GeoItemRenderer.RenderData, GeoRenderState> renderer, String boneName) {
        super(renderer, boneName, null);
    }

    @Override
    protected Identifier getTextureResource(GeoRenderState renderState) {
        if(renderState.hasGeckolibData(CustomDataTickets.SKIN_ID)) {
            return renderState.getGeckolibData(CustomDataTickets.SKIN_ID);
        }
        return super.getTextureResource(renderState);
    }
}

//Custom Renderer
public class GunRenderer extends GeoItemRenderer<ItemGun> {

    public <I extends ItemGun> GunRenderer(I item) {
        super(item);
        withRenderLayer(new GunCustomLayerRenderer(this, "right_arm"));
        withRenderLayer(new GunCustomLayerRenderer(this, "left_arm"));
    }

    @Override
    public void preRenderPass(RenderPassInfo<GeoRenderState> renderPassInfo, SubmitNodeCollector renderTasks) {
        super.preRenderPass(renderPassInfo, renderTasks);
    }

    @Override
    public void addRenderData(ItemGun animatable, @Nullable RenderData relatedObject, GeoRenderState renderState, float partialTick) {
        super.addRenderData(animatable, relatedObject, renderState, partialTick);
        if(!(relatedObject.itemOwner().asLivingEntity() instanceof AbstractClientPlayer player)) return;
        renderState.addGeckolibData(CustomDataTickets.SKIN_ID, player.getSkin().body().texturePath());
    }
}
```

## Before
Cube transformations affected subsequent cubes.
<img width="389" height="475" alt="image" src="https://github.com/user-attachments/assets/2306904c-c285-458f-b674-b7c48c42dc34" />

## After
Each cube maintains its own transform state.
<img width="327" height="395" alt="image" src="https://github.com/user-attachments/assets/7263bb0b-774a-442d-97e9-8f2ed4969bb7" />
