### PR TITLE
Supported model versions: Add 1.21.20 model version, rewrite warnings so they sound more like warnings and less like errors

### DIFF
--- a/Fabric/src/main/java/software/bernie/geckolib/cache/GeckoLibCache.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/cache/GeckoLibCache.java
@@ -105,7 +105,8 @@ public final class GeckoLibCache {
 						case V_1_14_0 -> GeckoLib.LOGGER.warn("Unsupported geometry json version: 1.14.0 for model {}. This model may not appear as expected", resource);
 						case V_1_21_0 -> GeckoLib.LOGGER.warn("Unsupported geometry json version: 1.21.0 for model {}. Supported versions: 1.12.0. Remove any rotated face UVs and re-export the model to fix", resource);
 						case V_1_21_2 -> GeckoLib.LOGGER.warn("Unsupported geometry json version: 1.21.2 for model {}. Supported versions: 1.12.0. Remove any rotated face UVs and re-export the model to fix", resource);
-						default -> GeckoLib.LOGGER.warn("Unsupported geometry json version for model {}. Supported versions: 1.12.0", resource);
+						default -> GeckoLib.LOGGER.warn("Unsupported geometry json version {} for model {}. Supported versions: 1.12.0",
+								model.formatVersion(), resource);
 					}
 				}
 

--- a/Fabric/src/main/java/software/bernie/geckolib/cache/GeckoLibCache.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/cache/GeckoLibCache.java
@@ -97,16 +97,24 @@ public final class GeckoLibCache {
 				Model model = FileLoader.loadModelFile(resource, resourceManager);
 
 				if (model.formatVersion() == null) {
-					GeckoLib.LOGGER.warn("Unsupported geometry json version for model {}. Supported versions: 1.12.0", resource);
+					GeckoLib.LOGGER.warn("Unknown geometry json version found for model {}." +
+							" Last known version: 1.12.0. Some features may not work as expected.", resource);
 				}
 				else {
 					switch (model.formatVersion()) {
 						case V_1_12_0 -> {}
-						case V_1_14_0 -> GeckoLib.LOGGER.warn("Unsupported geometry json version: 1.14.0 for model {}. This model may not appear as expected", resource);
-						case V_1_21_0 -> GeckoLib.LOGGER.warn("Unsupported geometry json version: 1.21.0 for model {}. Supported versions: 1.12.0. Remove any rotated face UVs and re-export the model to fix", resource);
-						case V_1_21_2 -> GeckoLib.LOGGER.warn("Unsupported geometry json version: 1.21.2 for model {}. Supported versions: 1.12.0. Remove any rotated face UVs and re-export the model to fix", resource);
-						default -> GeckoLib.LOGGER.warn("Unsupported geometry json version {} for model {}. Supported versions: 1.12.0",
-								model.formatVersion(), resource);
+						case V_1_14_0 ->
+								GeckoLib.LOGGER.warn("More recent geometry json version found: 1.14.0 for model {}. This model " +
+								"may not appear as expected", resource);
+						case V_1_21_0 ->
+								GeckoLib.LOGGER.warn("More recent geometry json version found: 1.21.0 for model {}. Last known " +
+								"version: 1.12.0. Remove any rotated face UVs or item display transforms, as GeckoLib does not support them.", resource);
+						case V_1_21_2, V_1_21_20 ->
+								GeckoLib.LOGGER.warn("More recent geometry json version found: {} for model {}. Last " +
+								"known version: 1.12.0. Remove any rotated face UVs or item display transforms, as GeckoLib does not " +
+								"support them.", model.formatVersion(), resource);
+						default -> GeckoLib.LOGGER.warn("Unknown geometry json version found: {} for model {}." +
+								" Last known version: 1.12.0. Some features may not work as expected.", model.formatVersion(), resource);
 					}
 				}
 

--- a/Fabric/src/main/java/software/bernie/geckolib/loading/json/FormatVersion.java
+++ b/Fabric/src/main/java/software/bernie/geckolib/loading/json/FormatVersion.java
@@ -9,5 +9,6 @@ public enum FormatVersion {
 	@SerializedName("1.12.0") V_1_12_0,
 	@SerializedName("1.14.0") V_1_14_0,
 	@SerializedName("1.21.0") V_1_21_0,
-	@SerializedName("1.21.2") V_1_21_2
+	@SerializedName("1.21.2") V_1_21_2,
+	@SerializedName("1.21.20") V_1_21_20
 }

--- a/Forge/src/main/java/software/bernie/geckolib/cache/GeckoLibCache.java
+++ b/Forge/src/main/java/software/bernie/geckolib/cache/GeckoLibCache.java
@@ -109,7 +109,8 @@ public final class GeckoLibCache {
 						case V_1_14_0 -> GeckoLib.LOGGER.warn("Unsupported geometry json version: 1.14.0 for model {}. This model may not appear as expected", resource);
 						case V_1_21_0 -> GeckoLib.LOGGER.warn("Unsupported geometry json version: 1.21.0 for model {}. Supported versions: 1.12.0. Remove any rotated face UVs and re-export the model to fix", resource);
 						case V_1_21_2 -> GeckoLib.LOGGER.warn("Unsupported geometry json version: 1.21.2 for model {}. Supported versions: 1.12.0. Remove any rotated face UVs and re-export the model to fix", resource);
-						default -> GeckoLib.LOGGER.warn("Unsupported geometry json version for model {}. Supported versions: 1.12.0", resource);
+						default -> GeckoLib.LOGGER.warn("Unsupported geometry json version {} for model {}. Supported versions: 1.12.0",
+								model.formatVersion(), resource);
 					}
 				}
 

--- a/Forge/src/main/java/software/bernie/geckolib/cache/GeckoLibCache.java
+++ b/Forge/src/main/java/software/bernie/geckolib/cache/GeckoLibCache.java
@@ -101,16 +101,24 @@ public final class GeckoLibCache {
 				Model model = FileLoader.loadModelFile(resource, resourceManager);
 
 				if (model.formatVersion() == null) {
-					GeckoLib.LOGGER.warn("Unsupported geometry json version for model {}. Supported versions: 1.12.0", resource);
+					GeckoLib.LOGGER.warn("Unknown geometry json version found for model {}." +
+							" Last known version: 1.12.0. Some features may not work as expected.", resource);
 				}
 				else {
 					switch (model.formatVersion()) {
 						case V_1_12_0 -> {}
-						case V_1_14_0 -> GeckoLib.LOGGER.warn("Unsupported geometry json version: 1.14.0 for model {}. This model may not appear as expected", resource);
-						case V_1_21_0 -> GeckoLib.LOGGER.warn("Unsupported geometry json version: 1.21.0 for model {}. Supported versions: 1.12.0. Remove any rotated face UVs and re-export the model to fix", resource);
-						case V_1_21_2 -> GeckoLib.LOGGER.warn("Unsupported geometry json version: 1.21.2 for model {}. Supported versions: 1.12.0. Remove any rotated face UVs and re-export the model to fix", resource);
-						default -> GeckoLib.LOGGER.warn("Unsupported geometry json version {} for model {}. Supported versions: 1.12.0",
-								model.formatVersion(), resource);
+						case V_1_14_0 ->
+								GeckoLib.LOGGER.warn("More recent geometry json version found: 1.14.0 for model {}. This model " +
+										"may not appear as expected", resource);
+						case V_1_21_0 ->
+								GeckoLib.LOGGER.warn("More recent geometry json version found: 1.21.0 for model {}. Last known " +
+										"version: 1.12.0. Remove any rotated face UVs or item display transforms, as GeckoLib does not support them.", resource);
+						case V_1_21_2, V_1_21_20 ->
+								GeckoLib.LOGGER.warn("More recent geometry json version found: {} for model {}. Last " +
+										"known version: 1.12.0. Remove any rotated face UVs or item display transforms, as GeckoLib does not " +
+										"support them.", model.formatVersion(), resource);
+						default -> GeckoLib.LOGGER.warn("Unknown geometry json version found: {} for model {}." +
+								" Last known version: 1.12.0. Some features may not work as expected.", model.formatVersion(), resource);
 					}
 				}
 

--- a/Forge/src/main/java/software/bernie/geckolib/loading/json/FormatVersion.java
+++ b/Forge/src/main/java/software/bernie/geckolib/loading/json/FormatVersion.java
@@ -9,5 +9,6 @@ public enum FormatVersion {
 	@SerializedName("1.12.0") V_1_12_0,
 	@SerializedName("1.14.0") V_1_14_0,
 	@SerializedName("1.21.0") V_1_21_0,
-	@SerializedName("1.21.2") V_1_21_2
+	@SerializedName("1.21.2") V_1_21_2,
+	@SerializedName("1.21.20") V_1_21_20
 }


### PR DESCRIPTION
Model formats have updated and changes a bit since 1.20.1 was released.
The warnings sound a bit like errors, they should sound warn some features may not work but _most_ things should be fine if reexported to 1.12, or replacing the format_version to 1.12.

Per face UVs and item display transforms arent supported, so if those are in a model, they won't work.
