### PR TITLE
Fix float precision loss in ClientUtil.getCurrentTick() on long-uptime worlds

### DIFF
--- a/common/src/main/java/com/geckolib/util/ClientUtil.java
+++ b/common/src/main/java/com/geckolib/util/ClientUtil.java
@@ -64,7 +64,7 @@ public final class ClientUtil {
         final Minecraft mc = Minecraft.getInstance();
 
         return mc.level != null ?
-               mc.level.getGameTime() + (partialTick != null ? partialTick : mc.getDeltaTracker().getGameTimeDeltaPartialTick(false)) :
+               (double) mc.level.getGameTime() + (partialTick != null ? partialTick : mc.getDeltaTracker().getGameTimeDeltaPartialTick(false)) :
                Blaze3D.getTime() * 20d;
     }
 


### PR DESCRIPTION
`getCurrentTick()` casts `level.getGameTime()` to a float before adding partial tick. This results in animation stutter - worse for older worlds.

This fixes animation stutter in old server worlds. Tested on worlds with gameTime < 100k ticks & gameTime >1b ticks: with the latter stuttering beforehand.